### PR TITLE
Added correct stm32 board config. It's f4 instead of f3

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,10 +18,16 @@
             "name": "Openocd Debug",
             "type": "cortex-debug",
             "servertype": "openocd",
-            "request": "launch",
+            "request": "attach",
             "executable": "${workspaceFolder}/jocktos/build/main.elf",
-            "configFiles": [ "target/board/stm32f4discovery.cfg" ],
-            "cwd": "${workspaceRoot}/jocktos"
+            "configFiles": ["interface/stlink.cfg",
+                "board/st_nucleo_f3.cfg"
+              ],
+            "showDevDebugOutput": "raw",
+            "cwd": "${workspaceRoot}/jocktos",
+            "gdbPath": "C:\\Program Files (x86)\\GNU Arm Embedded Toolchain\\10 2021.10\\bin\\arm-none-eabi-gdb.exe",
+            "gdbTarget": "localhost:3333"
+            
         },
     ]
 }


### PR DESCRIPTION
Sort of self-explanatory. Issues with gdb and openocd still need to be resolved with regards to how the program seems to be lost when debugging. Breakpoints are set, but are never reached however.

Perhaps some compiler flags  in the makefile could be changed for better debugging symbols? I am not sure at this time.

Keep in mind, the chip still is an ARM Cortex-M4. The only thing that has changed is the stm32 board.cfg in the launch json.

*TL;DR* : use "board/st_nucleo_f3.cfg" for openocd purposes.


![image](https://github.com/JGoard/JOCKTOS/assets/63118170/ce9e0e30-daed-4ea5-98f5-68a310b1f516)
