### PR TITLE
16bit Allocator

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,12 +24,8 @@ jobs:
       run: |
         sudo apt-get update
 
-    - name: Build jocktos
+    - name: Build All Tests
       run: cd jocktos/test && make
 
-    - name: Bitmap BLock Allocator
-      run: cd jocktos/test/build && ./allocator.test
-
-      
-
-  
+    - name: Bitmap Block Allocator
+      run: cd jocktos/test/build && ./test_allocator.test

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,32 +2,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "QEMU debug",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceFolder}/jocktos/build/firmware.elf",
-            "cwd": "${workspaceFolder}/jocktos",
-            "externalConsole": false,
-            "miDebuggerPath": "C:/Program Files (x86)/GNU Arm Embedded Toolchain/10 2021.10/bin/arm-none-eabi-gdb.exe",
-            "miDebuggerServerAddress": "localhost:1234",
-            "stopAtEntry": true,
-            "preLaunchTask": "run-qemu-emulator",
-            "postDebugTask": "stop-qemu-emulator",
-        },
-        {
-            "name": "Attach OpenOCD",
-            "type": "cortex-debug",
-            "servertype": "openocd",
-            "request": "attach",
-            "executable": "${workspaceFolder}/jocktos/build/firmware.elf",
-            "configFiles": [
-                "board/st_nucleo_f3.cfg",
-            ],
-            "showDevDebugOutput": "raw",
-            "cwd": "${workspaceFolder}/jocktos"
-            
-        },
-        {
             "name": "Launch OpenOCD",
             "cwd": "${workspaceFolder}/jocktos",
             "executable": "${workspaceFolder}/jocktos/build/firmware.elf",
@@ -52,6 +26,45 @@
                 "enabled": true,
                 "samplesPerSecond": 4
             }
+        },
+        {
+            "name": "Attach OpenOCD",
+            "type": "cortex-debug",
+            "servertype": "openocd",
+            "request": "attach",
+            "executable": "${workspaceFolder}/jocktos/build/firmware.elf",
+            "configFiles": [
+                "board/st_nucleo_f3.cfg",
+            ],
+            "showDevDebugOutput": "raw",
+            "cwd": "${workspaceFolder}/jocktos"
+            
+        },
+        {
+            "name": "Debug Current Unit Test",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/jocktos/test/build/${fileBasenameNoExtension}.test",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "preLaunchTask": "build current unit test"
+        },
+        {
+            "name": "QEMU debug",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/jocktos/build/firmware.elf",
+            "cwd": "${workspaceFolder}/jocktos",
+            "externalConsole": false,
+            "miDebuggerPath": "C:/Program Files (x86)/GNU Arm Embedded Toolchain/10 2021.10/bin/arm-none-eabi-gdb.exe",
+            "miDebuggerServerAddress": "localhost:1234",
+            "stopAtEntry": true,
+            "preLaunchTask": "run-qemu-emulator",
+            "postDebugTask": "stop-qemu-emulator",
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -81,6 +81,20 @@
       },
     },
     {
+      "label": "Run Unit Tests",
+      "type": "shell",
+      "command": "cd ${workspaceFolder}/jocktos/test; make run-tests",
+      "icon": {
+        "id": "run",
+        "color": "terminal.ansiWhite"
+      },
+      "options": {
+        "statusbar": {
+          "color" : "#ffffff"
+        }
+      }
+    },    
+    {
       "label": "Build Docs",
       "type": "shell",
       "command": "docker",
@@ -207,6 +221,16 @@
           "message": 1
         }
       }
+    },
+    {
+      "label": "build current unit test",
+      "type": "shell",
+      "command": "cd ${workspaceFolder}/jocktos/test; make build/${fileBasenameNoExtension}.test",
+      "options": {
+        "statusbar": {
+          "hide" : true
+        }
+      },
     }
   ]
 }

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -67,7 +67,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = /JOCKTOS/docs/build
+OUTPUT_DIRECTORY       = ../build
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create up to 4096
 # sub-directories (in 2 levels) under the output directory of each output format
@@ -906,7 +906,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  =/JOCKTOS/jocktos/
+INPUT                  =../../jocktos/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -995,7 +995,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = /JOCKTOS/jocktos/CubeMX/
+EXCLUDE                = ../../jocktos/CubeMX/
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/docs/source/bitmap_allocator.rst
+++ b/docs/source/bitmap_allocator.rst
@@ -1,0 +1,7 @@
+
+=================================================
+Bitmap Block Allocator
+=================================================
+
+.. doxygenfile:: allocator.c
+   :project: jocktos-docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,16 +4,16 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 import subprocess
 
-subprocess.call('doxygen /JOCKTOS/docs/Doxyfile', shell=True)
+subprocess.call('doxygen ../Doxyfile', shell=True)
 
 # Add Doxygen-generated files to Sphinx
 breathe_default_project = 'jocktos-docs'
 breathe_projects = {
-    'jocktos-docs': "/JOCKTOS/docs/build/xml",
+    'jocktos-docs': "../build/xml",
 }
 
 latex_engine = 'xelatex'  # or 'pdflatex' if you prefer
-latex_build_directory = '/JOCKTOS/docs/_latex'
+latex_build_directory = '../_latex'
 latex_elements = {
     'papersize': 'letterpaper',
     'pointsize': '10pt',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ A journey of learning how to create an RTOS kernel from the ground up, by Nick S
    :maxdepth: 2
    :caption: Contents:
 
-   source_code.rst
+   bitmap_allocator.rst
 
 Indices and tables
 ==================

--- a/jocktos/inc/allocator.h
+++ b/jocktos/inc/allocator.h
@@ -20,26 +20,26 @@
  * @brief A block of memory with a pointer to its head and its size.
  */
 typedef struct {
-    void* head;     ///< Pointer to the start of the memory block
-    size_t size;    ///< Size of the memory block
+    void* head;     ///< Pointer to the start of the memory block.
+    uint16_t size;  ///< Size of the memory block.
 } MemoryBlock;
 
 /**
  * @brief Bitmaps for tracking used and allocated memory.
  */
 typedef struct {
-    uint64_t* used;   ///< Bitmap tracking used blocks
-    uint64_t* alloc;  ///< Bitmap tracking allocated blocks
-    size_t size;      ///< Size of the bitmap
+    uint16_t* used;   ///< Bitmap tracking used blocks.
+    uint16_t* alloc;  ///< Bitmap tracking allocated blocks.
+    uint16_t size;    ///< Size of the bitmap.
 } BitMaps;
 
 /**
  * @brief Represents an allocator with bitmaps and a memory block.
  */
 typedef struct {
-    BitMaps bitmaps;      ///< Bitmaps for managing memory allocation
-    MemoryBlock memory;   ///< The memory block being managed
-    size_t blockSize;     ///< Size of each memory block
+    BitMaps bitmaps;      ///< Bitmaps for managing memory allocation.
+    MemoryBlock memory;   ///< The memory block being managed.
+    uint16_t blockSize;     ///< Size of each memory block.
 } Allocator;
 
 /* -- Externs (avoid these for library functions) ------------------------- */
@@ -49,28 +49,32 @@ typedef struct {
 /**
  * @brief Initializes an allocator.
  * 
- * @param allocator The allocator to initialize
- * @param memory The memory region to manage
- * @param size The size of the memory region
- * @param blockSize The size of each block
+ * @param allocator The allocator to initialize.
+ * @param memory The memory region to manage.
+ * @param size The size of the memory region.
+ * @param blockSize The size of each block.
+ * 
+ * @note
+ * The provided `memory` MUST point to a block of free, zero-initialized memory of size `size`.
  */
-void initAllocator(Allocator* allocator, void* memory, size_t size, size_t blockSize);
+void initAllocator(Allocator* allocator, void* memory, uint16_t size, uint16_t blockSize);
 
 /**
- * @brief Allocates a block of memory.
+ * @brief Allocates a block of memory from the allocator.
  * 
- * @param allocator The allocator to use for allocation
- * @param size The size of the memory block to allocate
- * @return A pointer to the allocated memory, or NULL if allocation fails
+ * @param allocator The allocator to use for allocation.
+ * @param size The size of the memory block to allocate in bytes.
+ * @return A pointer to the allocated memory block, or NULL if the space is unavailable.
  */
-void* allocate(Allocator* allocator, size_t size);
+void* allocate(Allocator* allocator, uint16_t size);
 
 /**
- * @brief Deallocates a previously allocated block of memory.
- * 
- * @param allocator The allocator to use for deallocation
- * @param ptr A pointer to the memory block to deallocate
- * @return True if deallocation is successful, false otherwise
+ * @brief Deallocates a previously allocated block of memory from the allocator.
+ *
+ * @param allocator The allocator to use for deallocation.
+ * @param ptr A pointer to the start of the block of memory to be deallocated.
+ *
+ * @return true if the block was successfully deallocated, false otherwise.
  */
 bool deallocate(Allocator* allocator, void* ptr);
 

--- a/jocktos/src/allocator.c
+++ b/jocktos/src/allocator.c
@@ -16,13 +16,14 @@
 /* -- Local Globals (not for libraries with application instantiation) ---- */
 
 /* -- Private Function Declarations --------------------------------------- */
+
 /**
  * @brief Sets the indexed bit to true.
  * 
  * @param bitmap The bitmap to be modified
  * @param index The index of the bit to be enabled
  */
-void setBit(uint64_t* bitmap, size_t index);
+void setBit(uint16_t* bitmap, uint16_t index);
 
 /**
  * @brief Sets the indexed bit to false.
@@ -30,7 +31,7 @@ void setBit(uint64_t* bitmap, size_t index);
  * @param bitmap The bitmap to be modified
  * @param index The index of the bit to be disabled
  */
-void clearBit(uint64_t* bitmap, size_t index);
+void clearBit(uint16_t* bitmap, uint16_t index);
 
 /**
  * @brief Get the value of the indexed bit.
@@ -38,86 +39,127 @@ void clearBit(uint64_t* bitmap, size_t index);
  * @param bitmap The bitmap to be sampled
  * @param index The index of the bit to be sampled
  */
-bool getBit(uint64_t* bitmap, size_t index);
+bool getBit(uint16_t* bitmap, uint16_t index);
 
 /**
  * @brief Finds a contiguous sequence of free blocks.
- * 
+ *
+ * @details
+ * This function takes a bitmap representing used blocks, the size of the bitmap, and the number of contiguous blocks needed.
+ * It iterates through each bit in the bitmap, keeping track of the count of consecutive free blocks.
+ * When it finds a sequence of `numBlocks` consecutive free blocks, it returns the index of the first block in the sequence.
+ * If it reaches the end of the bitmap without finding a suitable sequence, it returns SIZE_MAX.
+ *
  * @param used The bitmap representing used blocks
  * @param size The size of the bitmap
  * @param numBlocks The number of contiguous blocks needed
- * @return The index of the first block in the contiguous sequence if found, or -1 if not found
+ * @return The index of the first block in the contiguous sequence if found, or UINT16_MAX if not found
  */
-size_t findContiguousFreeBlocks(uint64_t* used, size_t size, size_t numBlocks);
+uint16_t findContiguousFreeBlocks(uint16_t* used, uint16_t size, uint16_t numBlocks);
 
 /* -- Public Functions----------------------------------------------------- */
 
-// Allocator functions
-void initAllocator(Allocator* allocator, void* memory, size_t size, size_t blockSize) {
-    size_t numBlocks = size / blockSize;
-    size_t bitmapSize = (numBlocks + 63) / 64 * 2 * sizeof(uint64_t);
-    allocator->bitmaps.size = (size - bitmapSize) / blockSize;
-    allocator->bitmaps.used = (uint64_t*)memory;
-    memory = (void*)((uintptr_t)memory + bitmapSize / 2);
-    allocator->bitmaps.alloc = (uint64_t*)memory;
-    memory = (void*)((uintptr_t)memory + bitmapSize / 2);
-    allocator->memory.head = memory;
-    allocator->memory.size = size - bitmapSize;
-    allocator->blockSize = blockSize;
+/**
+ * @details
+ * This function initializes an allocator with the provided parameters.
+ * The memory region pointed to by `memory` is divided into two parts:
+ * - A portion of the memory will be dedicated to the bitmaps. The size of this portion 
+ *   is calculated based on the number of blocks that can fit in the provided memory.
+ * - The other portion of the memory will be used to store the allocated blocks.
+ */
+void initAllocator(Allocator* allocator, void* memory, uint16_t size, uint16_t blockSize) {
+    // Calculate the number of blocks that can fit in the provided memory
+    uint16_t numBlocks = size / blockSize;
+    // Calculate the size of the bitmap portion of the memory region
+    uint16_t bitmapSize = ((numBlocks + 15) / 16) * 2 * sizeof(uint16_t);
+    // Initialize the allocator with the calculated values
+    allocator->bitmaps.size = (size - bitmapSize) / blockSize;  // Number of blocks in the memory region
+    allocator->bitmaps.used = (uint16_t*)memory;  // Pointer to the used bitmap
+    // Adjust the memory pointer to the start of the allocated block portion
+    memory = (void*)((uint8_t*)memory + bitmapSize / 2);
+    allocator->bitmaps.alloc = (uint16_t*)memory;  // Pointer to the allocated bitmap
+    // Adjust the memory pointer to the start of the allocated block portion
+    memory = (void*)((uint8_t*)memory + bitmapSize / 2);
+    allocator->memory.head = memory;  // Pointer to the start of the allocated block portion
+    allocator->memory.size = allocator->bitmaps.size * blockSize;  // Size of the allocated block portion
+    allocator->blockSize = blockSize;  // Size of each block
 }
 
-void* allocate(Allocator* allocator, size_t size) {
-    size_t numBlocks = (size + allocator->blockSize - 1) / allocator->blockSize;
-    size_t startIndex = findContiguousFreeBlocks(allocator->bitmaps.used, allocator->bitmaps.size, numBlocks);
-    if (startIndex == SIZE_MAX) {
+/**
+ * @details
+ * This function finds a contiguous sequence of free blocks in the allocator's bitmap and marks them as used.
+ * It then returns a pointer to the start of the allocated block.
+ * If no contiguous free blocks are available, it returns NULL.
+ */
+void* allocate(Allocator* allocator, uint16_t size) {
+    // Calculate the number of blocks needed to allocate the requested size
+    uint16_t numBlocks = (size + allocator->blockSize - 1) / allocator->blockSize;
+    // Find the index of the first contiguous free block in the bitmap
+    uint16_t startIndex = findContiguousFreeBlocks(allocator->bitmaps.used, allocator->bitmaps.size, numBlocks);
+    // If no contiguous free blocks are available, return NULL
+    if (startIndex == UINT16_MAX) {
         return NULL;
     }
-    for (size_t i = 0; i < numBlocks; i++) {
+    // Mark the allocated blocks as used in the bitmap
+    for (uint16_t i = 0; i < numBlocks; i++) {
         setBit(allocator->bitmaps.used, startIndex + i);
     }
+    // Mark the allocated blocks as allocated in the bitmap
     setBit(allocator->bitmaps.alloc, startIndex);
-    return (void*)((uintptr_t)allocator->memory.head + startIndex * allocator->blockSize);
+    // Calculate the pointer to the start of the allocated block
+    void* ptr = (void*)((uint8_t*)allocator->memory.head + startIndex * allocator->blockSize);
+    // Return the pointer to the allocated block
+    return ptr;
 }
 
+/**
+ * @details
+ * This function takes a pointer to the start of the block of memory to be deallocated and the allocator from which it was allocated.
+ * It calculates the index of the block in the allocator's memory and verifies that the block is currently allocated.
+ * It then clears the allocated bit for the block and all subsequent blocks in the bitmap.
+ * It returns true if the deallocation was successful, false otherwise.
+ */
 bool deallocate(Allocator* allocator, void* ptr) {
-    size_t index = ((uintptr_t)ptr - (uintptr_t)allocator->memory.head) / allocator->blockSize;
-    if (!getBit(allocator->bitmaps.alloc, index)) {
-        return false;
-    }
+    // Calculate the index of the block in the allocator's memory
+    uint16_t index = ((uint8_t*)ptr - (uint8_t*)allocator->memory.head) / allocator->blockSize;
+    // Check if the block is currently allocated
+    if (!getBit(allocator->bitmaps.alloc, index)) return false;
+    // Clear the allocated bit for the block
     clearBit(allocator->bitmaps.alloc, index);
+    // Traverse the bitmap, clearing the used bits for all blocks in the sequence
     while (getBit(allocator->bitmaps.used, index) && !getBit(allocator->bitmaps.alloc, index)) {
         clearBit(allocator->bitmaps.used, index++);
+        // Break if we reach the end of the bitmap
         if (index >= allocator->bitmaps.size) break;
     }
     return true;
 }
 
-
 /* -- Private Functions --------------------------------------------------- */
 
-size_t findContiguousFreeBlocks(uint64_t* used, size_t size, size_t numBlocks) {
-    size_t count = 0;
-    for (size_t i = 0; i < size; i++) {
-        if (!getBit(used, i)) {
-            count++;
-            if (count == numBlocks) {
-                return i - numBlocks + 1;
+uint16_t findContiguousFreeBlocks(uint16_t* used, uint16_t size, uint16_t numBlocks) {
+    uint16_t count = 0; // Initialize a counter to track consecutive free blocks
+    for (uint16_t i = 0; i < size; i++) { // Iterate through each bit in the bitmap
+        if (!getBit(used, i)) { // If the bit is not set (i.e., the block is free)
+            count++; // Increment the counter
+            if (count == numBlocks) { // If the counter equals the number of blocks needed
+                return i - numBlocks + 1; // Return the starting index of the sequence
             }
-        } else {
-            count = 0;
+        } else { // If the bit is set (i.e., the block is used)
+            count = 0; // Reset the counter
         }
     }
-    return SIZE_MAX;
+    return UINT16_MAX; // Return UINT16_MAX if no suitable sequence is found
 }
 
-void setBit(uint64_t* bitmap, size_t index) {
-    bitmap[index / 64] |= (1ULL << (index % 64));
+void setBit(uint16_t* bitmap, uint16_t index) {
+    bitmap[index / 16] |= (1ULL << (index % 16));
 }
 
-void clearBit(uint64_t* bitmap, size_t index) {
-    bitmap[index / 64] &= ~(1ULL << (index % 64));
+void clearBit(uint16_t* bitmap, uint16_t index) {
+    bitmap[index / 16] &= ~(1ULL << (index % 16));
 }
 
-bool getBit(uint64_t* bitmap, size_t index) {
-    return (bitmap[index / 64] & (1ULL << (index % 64))) != 0;
+bool getBit(uint16_t* bitmap, uint16_t index) {
+    return (bitmap[index / 16] & (1ULL << (index % 16))) != 0;
 }

--- a/jocktos/src/main.c
+++ b/jocktos/src/main.c
@@ -24,7 +24,7 @@ int main(void)
         .enableIdle = true,
         .enableMain = true,
         .enableMonitor = true,
-        .allocatorBlockSize = 128
+        .allocatorBlockSize = 256
     );
     /* Configures JOCKTOS Kernel with Default structure */
     configureJOCKTOS(&config);
@@ -32,7 +32,7 @@ int main(void)
     /* Sample Task Employing passing in a task argument of anytype */
     TestArgStruct test_val = {.value = 1234, .ID = "Test Val!\n"};
     T_TaskControlBlock testTask = T_TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=256, 
+        .u32StackSize_By=512, 
         .taskFunct=testArgsTask,
         .taskArg=(void*)&test_val,
         .u8Name="test args");
@@ -40,21 +40,21 @@ int main(void)
 
     /* Sample Sleep Task */
     T_TaskControlBlock sleepTask = T_TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=256, 
+        .u32StackSize_By=512, 
         .taskFunct=sleepTest,
         .u8Name="sleep test");
     createTask(&sleepTask);
 
     /* Sample Semaphore Task */
     T_TaskControlBlock lockTask = T_TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=256, 
+        .u32StackSize_By=512, 
         .taskFunct=mutexTestTask,
         .u8Name="semaphore test");
     createTask(&lockTask);
 
     /* Sample Task Monitor Stack Test Task */
     T_TaskControlBlock stackTask = T_TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=256, 
+        .u32StackSize_By=512, 
         .taskFunct=stackInflationTestTask,
         .u8Name="stack inflation");
     createTask(&stackTask);

--- a/jocktos/src/os.c
+++ b/jocktos/src/os.c
@@ -73,7 +73,7 @@ T_TaskControlBlock stackUsageMonitor = T_TASKCONTROLBLOCK_DEF(
         .u8Name="stack usage monitor");
 
 T_TaskControlBlock defaultOSIdle = T_TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=256, 
+        .u32StackSize_By=512, 
         .taskFunct=idleJOCKTOS,
         .u8Name="default OS idle task");
 
@@ -86,7 +86,7 @@ void createTask(T_TaskControlBlock* tcb) {
         JOCKTOS_TCBError.invalidTaskHandle++;
         return;
     }
-    tcb->u32TaskStackOverflow = (uintptr_t*)allocate(&allocator, tcb->u32StackSize_By * sizeof(uintptr_t));
+    tcb->u32TaskStackOverflow = (uintptr_t*)allocate(&allocator, tcb->u32StackSize_By);
     if (!tcb->u32TaskStackOverflow) {
         // TODO: better error handling
         JOCKTOS_TCBError.failedToAllocate++;
@@ -115,7 +115,7 @@ void switchRunningTask(volatile T_TaskControlBlock** head) {
 }
 
 void configureJOCKTOS(T_JocktosConfig* config) {
-    void* memory = calloc(ALLOCATOR_SIZE, 1);
+    void* memory = calloc(ALLOCATOR_SIZE, sizeof(uint8_t));
     initAllocator(&allocator, memory, ALLOCATOR_SIZE, config->allocatorBlockSize);
     if (config->enableMonitor) createTask(&stackUsageMonitor);
     if (config->enableMain) insertTCB(&JOCKTOSScheduler.running, &userMainControlBlock);
@@ -144,7 +144,7 @@ void runJOCKTOS(void) {
 void initializeStack(T_TaskControlBlock* tcb) {
     uintptr_t* taskStack = tcb->u32TaskStackOverflow;
     // set intermediate stack pointer to bottom of range
-    taskStack = (uintptr_t*)(taskStack + ((tcb->u32StackSize_By) / 8) * 8);
+    taskStack = (uintptr_t*)(taskStack + tcb->u32StackSize_By / sizeof(uintptr_t));
     // define tasks initial exception return stack
     uintptr_t* initStackPtr;
     //  - non-critical registers are initialized to their index

--- a/jocktos/test/Makefile
+++ b/jocktos/test/Makefile
@@ -14,7 +14,7 @@ SRCDIR = ../src
 OBJDIR = build
 
 # Executable name
-EXECS = $(OBJDIR)/allocator.test
+EXECS = $(OBJDIR)/test_allocator.test
 
 # Default target
 all: $(OBJDIR) $(EXECS)
@@ -25,8 +25,8 @@ $(OBJDIR):
 
 
 # Compile source files into object files
-$(OBJDIR)/allocator.test: test_allocator.c $(SRCDIR)/allocator.c
-	$(CC) $(CFLAGS) -o $(OBJDIR)/allocator.test test_allocator.c $(SRCDIR)/allocator.c $(INC)
+$(OBJDIR)/test_allocator.test: test_allocator.c $(SRCDIR)/allocator.c $(OBJDIR)
+	$(CC) $(CFLAGS) -o $(OBJDIR)/test_allocator.test test_allocator.c $(SRCDIR)/allocator.c $(INC)
 
 
 # Clean up build artifacts
@@ -35,7 +35,7 @@ clean:
 
 
 # Run all .test files in OBJDIR
-test: $(OBJDIR) $(EXECS)
+run-tests: $(OBJDIR) $(EXECS)
 	@for test in $(EXECS); do \
 		$$test; \
 	done

--- a/jocktos/test/test_allocator.c
+++ b/jocktos/test/test_allocator.c
@@ -3,8 +3,8 @@
 #include <stdbool.h>
 
 // recreation of private function for test purposes
-bool get_bit(uint64_t* bitmap, size_t index) {
-    return (bitmap[index / 64] & (1ULL << (index % 64))) != 0;
+bool get_bit(uint16_t* bitmap, uint16_t index) {
+    return (bitmap[index / 16] & (1ULL << (index % 16))) != 0;
 }
 
 void testInitAllocator(void) {
@@ -19,13 +19,13 @@ void testInitAllocator(void) {
         ASSERT_EQUAL_INT(allocator.bitmaps.size, 7, "incorrect bitmap size after initialization"); 
 
         ASSERT_EQUAL_PTR((uint8_t*)(allocator.bitmaps.used), memory, "alloc bitmap placement is wrong"); 
-        ASSERT_EQUAL_PTR((uint8_t*)(allocator.bitmaps.alloc), memory + 8, "used bitmap placement is wrong");  
-        ASSERT_EQUAL_PTR((uint8_t*)(allocator.memory.head), memory + 16, "alloc bitmap placement is wrong"); 
+        ASSERT_EQUAL_PTR((uint8_t*)(allocator.bitmaps.alloc), memory + 2, "used bitmap placement is wrong");  
+        ASSERT_EQUAL_PTR((uint8_t*)(allocator.memory.head), memory + 4, "alloc bitmap placement is wrong"); 
 
     } CASE_COMPLETE;
 
     TEST_CASE("bitmaps fill memory block") {
-        // TODO: test for case where 2x 64bit bitmaps exceed the size of the memory block
+        // TODO: test for case where 2x 16bit bitmaps exceed the size of the memory block
     } CASE_NOT_IMPLEMENTED;
 
     TEST_CASE("head aligned correctly") {
@@ -46,7 +46,7 @@ void testAllocate() {
         void* block2 = allocate(&allocator, 16);
         ASSERT_EQUAL_PTR(block2, NULL, "invalid allocation returned non-null");
         ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 0), "alloc bit not set");
-        for (size_t i = 0; i < allocator.bitmaps.size; i++) {
+        for (uint16_t i = 0; i < allocator.bitmaps.size; i++) {
             ASSERT_TRUE(get_bit(allocator.bitmaps.used, i), "used bit not set");
         }
     } CASE_COMPLETE;
@@ -60,29 +60,29 @@ void testAllocate() {
         void* block = allocate(&allocator, 1024);
         ASSERT_EQUAL_PTR(block, NULL, "invalid allocation returned non-null");
 
-        for (size_t i = 0; i < allocator.bitmaps.size; i++) {
+        for (uint16_t i = 0; i < allocator.bitmaps.size; i++) {
             ASSERT_FALSE(get_bit(allocator.bitmaps.alloc, i), "alloc bit was set");
             ASSERT_FALSE(get_bit(allocator.bitmaps.used, i),  "used bit was set");
         }
     } CASE_COMPLETE;
 
-    TEST_CASE("allocating block that spans two 64bit words in the bitmap") {
+    TEST_CASE("allocating block that spans two 16bit words in the bitmap") {
         Allocator allocator;
         uint8_t memory[4096];
         for (int index = 0; index < 4096; index++) memory[index] = 0;
-        initAllocator(&allocator, memory, 4096, 16);
+        initAllocator(&allocator, memory, 512, 16);
 
-        void* block1 = allocate(&allocator, 16 * 75);
+        void* block1 = allocate(&allocator, 16 * 20);
         void* block2 = allocate(&allocator, 16);
         ASSERT_NOT_EQUAL_PTR(block1, NULL, "valid allocation returned null");
         ASSERT_NOT_EQUAL_PTR(block2, NULL, "valid allocation returned null");
 
         ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 0), "alloc bit not set");
-        for (size_t i = 0; i < 75; i++) {
+        for (uint16_t i = 0; i < 20; i++) {
             ASSERT_TRUE(get_bit(allocator.bitmaps.used, i), "used bit not set");
         }
-        ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 75), "alloc bit not set");
-        ASSERT_TRUE(get_bit(allocator.bitmaps.used, 75), "used bit not set");
+        ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 20), "alloc bit not set");
+        ASSERT_TRUE(get_bit(allocator.bitmaps.used, 20), "used bit not set");
 
     } CASE_COMPLETE;
 
@@ -125,25 +125,25 @@ void testDeallocate() {
 
     } CASE_COMPLETE;
 
-    TEST_CASE("deallocating block that spans two 64bit words in the bitmap") {
+    TEST_CASE("deallocating block that spans two 16bit words in the bitmap") {
         Allocator allocator;
         uint8_t memory[4096];
         for (int index = 0; index < 4096; index++) memory[index] = 0;
         initAllocator(&allocator, memory, 4096, 16);
 
-        void* block1 = allocate(&allocator, 16 * 50);
-        void* block2 = allocate(&allocator, 16 * 75);
+        void* block1 = allocate(&allocator, 16 * 12);
+        void* block2 = allocate(&allocator, 16 * 20);
 
         ASSERT_TRUE(deallocate(&allocator, block1), "deallocating block1 failed");
 
         ASSERT_FALSE(get_bit(allocator.bitmaps.alloc, 0), "alloc bit still set after deallocation");
-        for (size_t i = 0; i < 50; i++) {
+        for (uint16_t i = 0; i < 12; i++) {
             ASSERT_FALSE(get_bit(allocator.bitmaps.used, i), "used bit still set after deallocation");
         }
 
-        ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 50), "next allocs bit cleared after deallocation");
-        for (size_t i = 0; i < 75; i++) {
-            ASSERT_TRUE(get_bit(allocator.bitmaps.used, 50 + i), "next used bit cleared after deallocation");
+        ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 12), "next allocs bit cleared after deallocation");
+        for (uint16_t i = 0; i < 20; i++) {
+            ASSERT_TRUE(get_bit(allocator.bitmaps.used, 12 + i), "next used bit cleared after deallocation");
         }
 
         ASSERT_TRUE(deallocate(&allocator, block2), "deallocating block2 failed");
@@ -158,7 +158,7 @@ void testDeallocate() {
         void* block = (uint8_t*)(allocator.memory.head) + 2;
 
         ASSERT_FALSE(deallocate(&allocator, block), "invalid block was deallocation without error");
-        for (size_t i = 0; i < 8; i++) {
+        for (uint16_t i = 0; i < 8; i++) {
             ASSERT_FALSE(get_bit(allocator.bitmaps.alloc, i), "alloc bit was cleared during invalid deallocation");
         }
     } CASE_COMPLETE;

--- a/jocktos/test/test_allocator.c
+++ b/jocktos/test/test_allocator.c
@@ -165,6 +165,7 @@ void testDeallocate() {
 }
 
 int main(void) {
+    LOG("ALLOCATOR TESTS\n", BLUE);
     TEST_EVAL(testInitAllocator);
     TEST_EVAL(testAllocate);
     TEST_EVAL(testDeallocate);

--- a/jocktos/test/test_utils.h
+++ b/jocktos/test/test_utils.h
@@ -35,6 +35,13 @@
 #include <stdlib.h>
 
 /* -- Defines ------------------------------------------------------------- */
+#define BLUE "\x1b[34m"
+#define GREEN "\x1b[32m"
+#define RED "\x1b[31m"
+#define RESET "\x1b[0m"
+#define CYAN "\x1b[36m"
+
+#define LOG(msg, col)   printf(col "%s" RESET, msg);
 
 /**
  * @brief Evaluate a statement and print its name.

--- a/jocktos/test/test_utils.h
+++ b/jocktos/test/test_utils.h
@@ -4,6 +4,7 @@
  * 
  * This header provides the following basic components:
  * 
+ * - LOG: Prints a message to the console in the specified color.
  * - TEST_EVAL: Wrapper for test function execution.
  * - TEST_CASE: Wrapper for test case separation (within a test function). This has the following companions:
  * - - CASE_COMPLETE: Indicates the end of a test case.
@@ -40,6 +41,8 @@
 #define RED "\x1b[31m"
 #define RESET "\x1b[0m"
 #define CYAN "\x1b[36m"
+#define MAGENTA "\x1b[35m"
+#define YELLOW "\x1b[33m"
 
 #define LOG(msg, col)   printf(col "%s" RESET, msg);
 
@@ -49,7 +52,7 @@
  * @param arg The test function to evaluate.
  */
 #define TEST_EVAL(arg)                      \
-    printf("\x1b[35m%s():\033[0m\n", #arg); \
+    printf(MAGENTA "%s():\n" RESET, #arg);  \
     depth++;                                \
     arg();                                  \
     depth--;
@@ -62,44 +65,45 @@
 #define TEST_CASE(name)                         \
     clear_case();                               \
     print_indent();                             \
-    printf("\x1b[34mcase: \033[0m%s\n", name);  \
+    printf(BLUE "case: " RESET "%s\n", name);   \
     inc_depth();                                \
 
 /**
  * @brief Indicate that the current test case has completed.
  */
-#define CASE_COMPLETE                           \
-    if(get_case_status()) {                     \
-        print_indent();                         \
-        printf("\x1b[32m:: passed\033[0m\n");   \
-    } dec_depth();                              \
+#define CASE_COMPLETE                       \
+    if(get_case_status()) {                 \
+        print_indent();                     \
+        printf(GREEN ":: passed\n" RESET);  \
+    } dec_depth();                          \
 
 /**
  * @brief Print a message indicating that a test case is not yet implemented.
  * 
  */
-#define CASE_NOT_IMPLEMENTED                            \
-    print_indent();                                     \
-    printf("\x1b[33mTEST NOT IMPLEMENTED\033[0m\n");    \
-    dec_depth();                                        \
+#define CASE_NOT_IMPLEMENTED                        \
+    print_indent();                                 \
+    printf(YELLOW "TEST NOT IMPLEMENTED\n" RESET);  \
+    dec_depth();                                    \
 
-#define __ASSERT_BOOL(cond, cond_str, expression, msg)                                  \
-    if (cond(expression)) {                                                             \
-        fail_case();                                                                    \
-        fail_test();                                                                    \
-        print_indent();                                                                 \
-        printf("\x1b[31mASSERT_" cond_str ": [%s] :: %s\033[0m\n", #expression, msg);   \
+#define __ASSERT_BOOL(cond, cond_str, expression, msg)                              \
+    if (cond(expression)) {                                                         \
+        fail_case();                                                                \
+        fail_test();                                                                \
+        print_indent();                                                             \
+        printf(RED "ASSERT_" cond_str ": [%s] :: %s\n" RESET, #expression, msg);    \
     }
 
 #define ASSERT_TRUE(expression, msg)  __ASSERT_BOOL(!, "TRUE",expression, msg)
 #define ASSERT_FALSE(expression, msg) __ASSERT_BOOL( , "FALSE", expression, msg)
 
-#define __ASSERT_CHECK(cond, cond_str, type, a, b, msg)                                                                             \
-    if (a cond b) {                                                                                                                 \
-        fail_case();                                                                                                                \
-        fail_test();                                                                                                                \
-        print_indent();                                                                                                             \
-        printf("\x1b[31mASSERT_" cond_str "EQUAL: %s "#cond" %s [%" type " "#cond" %" type "] :: %s\033[0m\n", #a, #b, a, b, msg);  \
+#define __ASSERT_CHECK(cond, cond_str, type, a, b, msg)                     \
+    if (a cond b) {                                                         \
+        fail_case();                                                        \
+        fail_test();                                                        \
+        print_indent();                                                     \
+        printf(RED "ASSERT_" cond_str "EQUAL: %s "#cond" %s ["              \
+        "%" type " "#cond" %" type "] :: %s\n" RESET, #a, #b, a, b, msg);   \
     }
 
 #define ASSERT_EQUAL_PTR(a, b, msg)           __ASSERT_CHECK(!=, "", "p", a, b, msg)


### PR DESCRIPTION
Changes:
 - Bitmaps are now 16bit, rather than 64bit. I realized that there will always be N * 2 * \<bitmap bits\>, so 16 bitmap bits will also preserve alignment for 32bit systems.
 - Variables for block sizes, allocation sizes, and bitmap indices have also been changed to 16bit (unsigned). 

Fixes:
 - TCB stack allocations have been rescaled to correctly allocate the requested size. This required some updates to the "bottom of stack" calculation, which was not accounting for the size if the pointer's type.
 - Docs workflow was failing the doxygen build due to invalid file paths. 
 
Docs:
 - In code comments and function descriptions have been improved.
 - New page added to documentation [WIP].
 
Misc:
 - Included terminal color macros to clean up the unit testing header file