### PR TITLE
remove hungarian notation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,43 @@
+Checks:
+  readability-identifier-naming,
+  clang-analyzer-*,
+  modernize-*,
+  performance-*,
+  bugprone-*,
+  misc-*
+
+CheckOptions:
+  - key: readability-identifier-naming.TypedefCase
+    value: CamelCase
+
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+
+  - key: readability-identifier-naming.MemberCase
+    value: lower_case
+
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+
+  - key: readability-identifier-naming.EnumConstantCase
+    value: UPPER_CASE
+
+  - key: readability-identifier-naming.ConstantCase
+    value: UPPER_CASE
+
+  # Ignore functions with the prefix `jock_`, or suffix `_Handler`
+  - key: readability-identifier-naming.FunctionIgnoredRegexp
+    value: '^jock_.*$|^.*_Handler$' 
+
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+
+  - key: readability-identifier-naming.GlobalVariableCase
+    value: lower_case
+
+  # Ignore variables with the prefix `JOCKTOS`
+  - key: readability-identifier-naming.GlobalVariableIgnoredRegexp
+    value: '^JOCKTOS.*$'

--- a/.vscode/JOCKTOS.code-workspace
+++ b/.vscode/JOCKTOS.code-workspace
@@ -19,7 +19,8 @@
           "tomoki1207.pdf",
           "dan-c-underwood.arm",
           "zixuanwang.linkerscript",
-          "trond-snekvik.gnu-mapfiles"
+          "trond-snekvik.gnu-mapfiles",
+          "CS128.cs128-clang-tidy"
         ]
       },
       "settings": {

--- a/jocktos/inc/allocator.h
+++ b/jocktos/inc/allocator.h
@@ -29,7 +29,7 @@ typedef struct {
  */
 typedef struct {
     uint16_t* used;   ///< Bitmap tracking used blocks.
-    uint16_t* alloc;  ///< Bitmap tracking allocated blocks.
+    uint16_t* heads;  ///< Bitmap tracking allocated block heads.
     uint16_t size;    ///< Size of the bitmap.
 } BitMaps;
 
@@ -39,7 +39,7 @@ typedef struct {
 typedef struct {
     BitMaps bitmaps;      ///< Bitmaps for managing memory allocation.
     MemoryBlock memory;   ///< The memory block being managed.
-    uint16_t blockSize;     ///< Size of each memory block.
+    uint16_t block_size;  ///< Size of each memory block.
 } Allocator;
 
 /* -- Externs (avoid these for library functions) ------------------------- */
@@ -50,14 +50,14 @@ typedef struct {
  * @brief Initializes an allocator.
  * 
  * @param allocator The allocator to initialize.
+ * @param block_size The size of each block.
  * @param memory The memory region to manage.
  * @param size The size of the memory region.
- * @param blockSize The size of each block.
  * 
  * @note
  * The provided `memory` MUST point to a block of free, zero-initialized memory of size `size`.
  */
-void initAllocator(Allocator* allocator, void* memory, uint16_t size, uint16_t blockSize);
+void initAllocator(Allocator* allocator, uint16_t block_size, void* memory, uint16_t size);
 
 /**
  * @brief Allocates a block of memory from the allocator.

--- a/jocktos/inc/main.h
+++ b/jocktos/inc/main.h
@@ -25,7 +25,7 @@
  */
 typedef struct {
     int value;    ///< Integer value.
-    char ID[10];  ///< String ID.
+    char id[10];  ///< String ID.
 } TestArgStruct;
 
 /* -- Externs (avoid these for library functions) ------------------------- */

--- a/jocktos/inc/os.h
+++ b/jocktos/inc/os.h
@@ -29,7 +29,7 @@
 /** 
  * @brief Default JOCKTOS configuration
  */
-#define T_JOCKTOSCONFIG_DEF(...) \
+#define JOCKTOSCONFIG_DEF(...) \
 {                                \
     .enableMonitor      = false, \
     .enableMain         = false, \
@@ -45,10 +45,10 @@
 typedef struct {
     volatile bool pending;
     volatile uint32_t tickCount;
-    volatile T_TaskControlBlock* running;   ///<    Currently running task
-    volatile T_TaskControlBlock* ready;     ///<    Singly linked list of tasks ready to run, in decending order of priority
-    volatile T_TaskControlBlock* suspended; ///<    Singly linked list of suspended tasks, in decending order of priority
-} T_Scheduler;
+    volatile TaskControlBlock* running;   ///<    Currently running task
+    volatile TaskControlBlock* ready;     ///<    Singly linked list of tasks ready to run, in decending order of priority
+    volatile TaskControlBlock* suspended; ///<    Singly linked list of suspended tasks, in decending order of priority
+} Scheduler;
 
 /**
  * @brief Configuration settings for JOCKTOS allocator and built in tasks
@@ -58,11 +58,11 @@ typedef struct {
     bool enableIdle;           ///< Enable or disable idle task
     bool enableMain;           ///< return execution after enabling, with `main` considered a new task
     size_t allocatorBlockSize; ///< Size of the allocator block
-} T_JocktosConfig;
+} JocktosConfig;
 
 /* -- Externs (avoid these for library functions) ------------------------- */
 
-extern T_Scheduler JOCKTOSScheduler;
+extern Scheduler JOCKTOSScheduler;
 
 /* -- Function Declarations ----------------------------------------------- */
 
@@ -74,7 +74,7 @@ extern T_Scheduler JOCKTOSScheduler;
  *
  * \param tcb Pointer to the task control block representing the new task.
  */
-void createTask(T_TaskControlBlock* tcb);
+void createTask(TaskControlBlock* tcb);
 
 /**
  * \brief Switch the currently running task
@@ -83,12 +83,12 @@ void createTask(T_TaskControlBlock* tcb);
  *
  * \param head Pointer to destination for current running task.
  */
-void switchRunningTask(volatile T_TaskControlBlock** head);
+void switchRunningTask(volatile TaskControlBlock** head);
 
 /**
  * \brief configure / enable built in OS tasks
  */
-void configureJOCKTOS(T_JocktosConfig* config);
+void configureJOCKTOS(JocktosConfig* config);
 
 /**
  * \brief Enable scheduler and context switching ISR's

--- a/jocktos/inc/os.h
+++ b/jocktos/inc/os.h
@@ -29,13 +29,13 @@
 /** 
  * @brief Default JOCKTOS configuration
  */
-#define JOCKTOSCONFIG_DEF(...) \
-{                                \
-    .enableMonitor      = false, \
-    .enableMain         = false, \
-    .enableIdle         = false, \
-    .allocatorBlockSize = 128,   \
-     __VA_ARGS__                 \
+#define JOCKTOSCONFIG_DEF(...)      \
+{                                   \
+    .enable_monitor      = false,   \
+    .enable_main         = false,   \
+    .enable_idle         = false,   \
+    .allocator_block_size = 256,    \
+     __VA_ARGS__                    \
 }
 /* -- Types --------------------------------------------------------------- */
 
@@ -44,7 +44,7 @@
  */
 typedef struct {
     volatile bool pending;
-    volatile uint32_t tickCount;
+    volatile uint32_t tick_count;
     volatile TaskControlBlock* running;   ///<    Currently running task
     volatile TaskControlBlock* ready;     ///<    Singly linked list of tasks ready to run, in decending order of priority
     volatile TaskControlBlock* suspended; ///<    Singly linked list of suspended tasks, in decending order of priority
@@ -54,10 +54,10 @@ typedef struct {
  * @brief Configuration settings for JOCKTOS allocator and built in tasks
  */
 typedef struct {
-    bool enableMonitor;        ///< Enable or disable monitoring
-    bool enableIdle;           ///< Enable or disable idle task
-    bool enableMain;           ///< return execution after enabling, with `main` considered a new task
-    size_t allocatorBlockSize; ///< Size of the allocator block
+    bool enable_monitor;         ///< Enable or disable monitoring
+    bool enable_idle;            ///< Enable or disable idle task
+    bool enable_main;            ///< return execution after enabling, with `main` considered a new task
+    size_t allocator_block_size; ///< Size of the allocator block
 } JocktosConfig;
 
 /* -- Externs (avoid these for library functions) ------------------------- */
@@ -104,6 +104,6 @@ void jock_run(void);
  * unsigned 32 bit millisecond counter
  * 
  */
-static inline uint32_t jock_currentTime() { return JOCKTOSScheduler.tickCount; }
+static inline uint32_t jock_currentTime() { return JOCKTOSScheduler.tick_count; }
 
 #endif /* _OS_H_ */

--- a/jocktos/inc/os.h
+++ b/jocktos/inc/os.h
@@ -74,7 +74,7 @@ extern Scheduler JOCKTOSScheduler;
  *
  * \param tcb Pointer to the task control block representing the new task.
  */
-void createTask(TaskControlBlock* tcb);
+void jock_createTask(TaskControlBlock* tcb);
 
 /**
  * \brief Switch the currently running task
@@ -88,7 +88,7 @@ void switchRunningTask(volatile TaskControlBlock** head);
 /**
  * \brief configure / enable built in OS tasks
  */
-void configureJOCKTOS(JocktosConfig* config);
+void jock_configure(JocktosConfig* config);
 
 /**
  * \brief Enable scheduler and context switching ISR's
@@ -96,7 +96,7 @@ void configureJOCKTOS(JocktosConfig* config);
  * Sets the priorities and enables systick and pendSV handlers
  *
  */
-void runJOCKTOS(void);
+void jock_run(void);
 
 /**
  * \brief returns the current OS tick count
@@ -104,6 +104,6 @@ void runJOCKTOS(void);
  * unsigned 32 bit millisecond counter
  * 
  */
-static inline uint32_t currentTime() { return JOCKTOSScheduler.tickCount; }
+static inline uint32_t jock_currentTime() { return JOCKTOSScheduler.tickCount; }
 
 #endif /* _OS_H_ */

--- a/jocktos/inc/synchro.h
+++ b/jocktos/inc/synchro.h
@@ -16,7 +16,7 @@
 /**
  * @brief default semaphore is binary (mutex)
  */
-#define T_SEMAPHORE_DEF(...)    \
+#define SEMAPHORE_DEF(...)    \
 {   /* ---Internal Data---*/    \
     .value_           = 1,      \
     .count            = 2,      \
@@ -33,9 +33,9 @@
 typedef struct {
     uint16_t value_;                                ///< [INTERNAL] current value
     uint16_t count;                                 ///< Queue size for lock instance
-    volatile T_TaskControlBlock *pendingTCBQueue_;  ///< [INTERNAL] Linked list of tasks awaiting lock
+    volatile TaskControlBlock *pendingTCBQueue_;  ///< [INTERNAL] Linked list of tasks awaiting lock
     uint8_t ownersPriority_;                        ///< [INTERNAL] TODO: prevent priority inversion
-} T_Semaphore;
+} Semaphore;
 
 /* -- Externs (avoid these for library functions) ------------------------- */
 
@@ -50,7 +50,7 @@ typedef struct {
  * 
  * @param lock Pointer to the semaphore to be taken.
  */
-void takeSemaphore(T_Semaphore* lock);
+void takeSemaphore(Semaphore* lock);
 
 /**
  * @brief Gives a semaphore.
@@ -62,7 +62,7 @@ void takeSemaphore(T_Semaphore* lock);
  * 
  * @param lock Pointer to the semaphore to be given.
  */
-void giveSemaphore(T_Semaphore* lock);
+void giveSemaphore(Semaphore* lock);
 
 /**
  * @brief Suspends the current running task for a fixed amount of time.

--- a/jocktos/inc/synchro.h
+++ b/jocktos/inc/synchro.h
@@ -50,7 +50,7 @@ typedef struct {
  * 
  * @param lock Pointer to the semaphore to be taken.
  */
-void takeSemaphore(Semaphore* lock);
+void jock_takeSemaphore(Semaphore* lock);
 
 /**
  * @brief Gives a semaphore.
@@ -62,13 +62,13 @@ void takeSemaphore(Semaphore* lock);
  * 
  * @param lock Pointer to the semaphore to be given.
  */
-void giveSemaphore(Semaphore* lock);
+void jock_giveSemaphore(Semaphore* lock);
 
 /**
  * @brief Suspends the current running task for a fixed amount of time.
  * 
  * @param delay (milliseconds)
  */
-void sleep(uint32_t delay);
+void jock_sleep(uint32_t delay);
 
 #endif // _SEMAPHORE_H_

--- a/jocktos/inc/synchro.h
+++ b/jocktos/inc/synchro.h
@@ -16,12 +16,12 @@
 /**
  * @brief default semaphore is binary (mutex)
  */
-#define SEMAPHORE_DEF(...)    \
+#define SEMAPHORE_DEF(...)      \
 {   /* ---Internal Data---*/    \
     .value_           = 1,      \
     .count            = 2,      \
-    .pendingTCBQueue_ = NULL,   \
-    .ownersPriority_  = 0,      \
+    .pending_queue_ = NULL,     \
+    .owners_priority_  = 0,     \
      __VA_ARGS__                \
 }
 
@@ -33,8 +33,8 @@
 typedef struct {
     uint16_t value_;                                ///< [INTERNAL] current value
     uint16_t count;                                 ///< Queue size for lock instance
-    volatile TaskControlBlock *pendingTCBQueue_;  ///< [INTERNAL] Linked list of tasks awaiting lock
-    uint8_t ownersPriority_;                        ///< [INTERNAL] TODO: prevent priority inversion
+    volatile TaskControlBlock *pending_queue_;      ///< [INTERNAL] Linked list of tasks awaiting lock
+    uint8_t owners_priority_;                       ///< [INTERNAL] TODO: prevent priority inversion
 } Semaphore;
 
 /* -- Externs (avoid these for library functions) ------------------------- */
@@ -67,8 +67,8 @@ void jock_giveSemaphore(Semaphore* lock);
 /**
  * @brief Suspends the current running task for a fixed amount of time.
  * 
- * @param delay (milliseconds)
+ * @param delay_ms (milliseconds)
  */
-void jock_sleep(uint32_t delay);
+void jock_sleep(uint32_t delay_ms);
 
 #endif // _SEMAPHORE_H_

--- a/jocktos/inc/tcb.h
+++ b/jocktos/inc/tcb.h
@@ -16,20 +16,20 @@
 /**
  * @brief default task control block
  */
-#define TASKCONTROLBLOCK_DEF(...) \
+#define TASKCONTROLBLOCK_DEF(...)   \
 {   /* ---- Configured ---*/        \
-    .priority      = 0,           \
-    .name          = 0,           \
-    .delay        = 0,           \
-    .stackSize_By = 0,           \
+    .priority = 0,                  \
+    .name     = "\0",               \
+    .delay_ms = 0,                  \
+    .stack_size_bytes = 0,          \
     /* ---- Input Data ---*/        \
-    .taskFunct       = NULL,        \
-    .taskArg         = NULL,        \
+    .task_handle = NULL,            \
+    .task_arg    = NULL,            \
     /* ---- Output Data---*/        \
-    .state          = BLOCKED,    \
+    .state = BLOCKED,               \
     /* ---- Internal Data-*/        \
-    .taskStackPointer = NULL,    \
-    .TCBNext             = NULL,    \
+    .stack_pointer = NULL,          \
+    .next          = NULL,          \
      __VA_ARGS__                    \
 }
 
@@ -49,11 +49,11 @@ typedef enum {
  * @brief colelction of potential error counters
  */
 typedef struct {
-    volatile uint16_t invalidTaskHandle;
-    volatile uint16_t failedToAllocate;
-    volatile uint16_t invalidListHead;
-    volatile uint16_t invalidTCB;
-    volatile uint16_t invalidListElement;
+    volatile uint16_t invalid_task_handle;   ///< TaskControlBlock initialized with a task handle
+    volatile uint16_t failed_to_allocate;    ///< TaskControlBlock initialized failed to allocate the requested task stack size
+    volatile uint16_t invalid_list_head;     ///< Attempted to modify a list with a void list head
+    volatile uint16_t invalid_tcb;           ///< Void TaskControlBlock pointer used in a list
+    volatile uint16_t invalid_list_element;  ///< Provided a TCB that is not in the list
 } TCBError;
 
 /** 
@@ -65,22 +65,17 @@ typedef void (*FunctionHandle)(void*);
  * @brief Cortex-M4 Context Control Block
  */
 typedef struct TaskControlBlock {
-    /* ---- Configured ---*/
-    volatile double      stackUsage;            ///<    Percentage of stack used as of last preemption
-    volatile uint8_t     priority;            ///<    The priority of the task
-    char*                name;                ///<    Name of the tast
-    uintptr_t            stackSize_By;       ///<    Configured task stack size
-    uint32_t             delay;              ///<    Delay in ms on 
-    /* ---- Input Data ---*/
-    FunctionHandle     taskFunct;             ///<    Main function handle for task
-    void*                taskArg;               ///<    Argument to be passed into the task function
-    /* ---- Output Data---*/
-    volatile TaskState state;                ///<    Defines current task state
-    /* ---- Working Data--*/
-    /* ---- Internal Data-*/
-    uintptr_t*           taskStackOverflow;  ///<    lowest accessible address for this tasks stack pointer
-    volatile uintptr_t*  taskStackPointer;   ///<    Hold's the current task stack pointer
-    volatile struct TaskControlBlock* TCBNext;///<    Next item for singly linked list
+    volatile double  stack_usage;               ///< Percentage of stack used as of last preemption
+    volatile uint8_t priority;                  ///< The priority of the task
+    char*            name;                      ///< Name of the task
+    uintptr_t        stack_size_bytes;          ///< Configured task stack size
+    uint32_t         delay_ms;                  ///< Delay in ms on 
+    void             (*task_handle)(void*);     ///< Main function handle for task
+    void*            task_arg;                  ///< Argument to be passed into the task function
+    volatile TaskState state;                   ///< Defines current task state
+    uintptr_t*          stack_overflow;         ///< Lowest accessible address for this tasks stack pointer
+    volatile uintptr_t* stack_pointer;          ///< Hold's the current task stack pointer
+    volatile struct TaskControlBlock* next;     ///< Next item for singly linked list
 } TaskControlBlock;
 
 /* -- Externs (avoid these for library functions) ------------------------- */
@@ -127,10 +122,10 @@ void updateTCB(volatile TaskControlBlock** head, volatile TaskControlBlock* tcb,
  * This function moves a task control block from one linked list to another. It first removes the task
  * control block from the current linked list, and then inserts it into the new linked list.
  *
- * \param currentHead Pointer to the pointer to the head of the current linked list.
- * \param newHead Pointer to the pointer to the head of the new linked list.
+ * \param source Pointer to the pointer to the head of the current linked list.
  * \param tcb Pointer to the task control block to be moved.
+ * \param destination Pointer to the pointer to the head of the new linked list.
  */
-void moveTCB(volatile TaskControlBlock** currentHead, volatile TaskControlBlock** newHead, volatile TaskControlBlock* tcb);
+void moveTCB(volatile TaskControlBlock** source, volatile TaskControlBlock* tcb, volatile TaskControlBlock** destination);
 
 #endif // _TCB_H_

--- a/jocktos/inc/tcb.h
+++ b/jocktos/inc/tcb.h
@@ -16,19 +16,19 @@
 /**
  * @brief default task control block
  */
-#define T_TASKCONTROLBLOCK_DEF(...) \
+#define TASKCONTROLBLOCK_DEF(...) \
 {   /* ---- Configured ---*/        \
-    .u8Priority      = 0,           \
-    .u8Name          = 0,           \
-    .u32Delay        = 0,           \
-    .u32StackSize_By = 0,           \
+    .priority      = 0,           \
+    .name          = 0,           \
+    .delay        = 0,           \
+    .stackSize_By = 0,           \
     /* ---- Input Data ---*/        \
     .taskFunct       = NULL,        \
     .taskArg         = NULL,        \
     /* ---- Output Data---*/        \
-    .eState          = eBLOCKED,    \
+    .state          = BLOCKED,    \
     /* ---- Internal Data-*/        \
-    .u32TaskStackPointer = NULL,    \
+    .taskStackPointer = NULL,    \
     .TCBNext             = NULL,    \
      __VA_ARGS__                    \
 }
@@ -39,11 +39,11 @@
  * @brief Enumeration of possible task states (stale feature)
  */
 typedef enum {
-    eRUNNING    = 0,    /**< Currently active task. */
-    eREADY      = 1,    /**< In the queue and ready to run. */
-    eBLOCKED    = 2,    /**< Awaiting a resource. */
-    eSUSPENDED  = 3    /**< Delayed or intentionally released. */
-} E_TaskState;
+    RUNNING    = 0,    /**< Currently active task. */
+    READY      = 1,    /**< In the queue and ready to run. */
+    BLOCKED    = 2,    /**< Awaiting a resource. */
+    SUSPENDED  = 3    /**< Delayed or intentionally released. */
+} TaskState;
 
 /** 
  * @brief colelction of potential error counters
@@ -54,34 +54,34 @@ typedef struct {
     volatile uint16_t invalidListHead;
     volatile uint16_t invalidTCB;
     volatile uint16_t invalidListElement;
-} T_TCBError;
+} TCBError;
 
 /** 
  * @brief Task function handle
  */
-typedef void (*T_FunctionHandle)(void*);
+typedef void (*FunctionHandle)(void*);
 
 /** 
  * @brief Cortex-M4 Context Control Block
  */
-typedef struct T_TaskControlBlock {
+typedef struct TaskControlBlock {
     /* ---- Configured ---*/
     volatile double      stackUsage;            ///<    Percentage of stack used as of last preemption
-    volatile uint8_t     u8Priority;            ///<    The priority of the task
-    char*                u8Name;                ///<    Name of the tast
-    uintptr_t            u32StackSize_By;       ///<    Configured task stack size
-    uint32_t             u32Delay;              ///<    Delay in ms on 
+    volatile uint8_t     priority;            ///<    The priority of the task
+    char*                name;                ///<    Name of the tast
+    uintptr_t            stackSize_By;       ///<    Configured task stack size
+    uint32_t             delay;              ///<    Delay in ms on 
     /* ---- Input Data ---*/
-    T_FunctionHandle     taskFunct;             ///<    Main function handle for task
+    FunctionHandle     taskFunct;             ///<    Main function handle for task
     void*                taskArg;               ///<    Argument to be passed into the task function
     /* ---- Output Data---*/
-    volatile E_TaskState eState;                ///<    Defines current task state
+    volatile TaskState state;                ///<    Defines current task state
     /* ---- Working Data--*/
     /* ---- Internal Data-*/
-    uintptr_t*           u32TaskStackOverflow;  ///<    lowest accessible address for this tasks stack pointer
-    volatile uintptr_t*  u32TaskStackPointer;   ///<    Hold's the current task stack pointer
-    volatile struct T_TaskControlBlock* TCBNext;///<    Next item for singly linked list
-} T_TaskControlBlock;
+    uintptr_t*           taskStackOverflow;  ///<    lowest accessible address for this tasks stack pointer
+    volatile uintptr_t*  taskStackPointer;   ///<    Hold's the current task stack pointer
+    volatile struct TaskControlBlock* TCBNext;///<    Next item for singly linked list
+} TaskControlBlock;
 
 /* -- Externs (avoid these for library functions) ------------------------- */
 
@@ -95,7 +95,7 @@ typedef struct T_TaskControlBlock {
  * \param head Pointer to the head of the linked list.
  * \param tcb Pointer to the task control block to be inserted.
  */
-void insertTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* tcb);
+void insertTCB(volatile TaskControlBlock** head, volatile TaskControlBlock* tcb);
 
 /**
  * \brief Remove a task control block from a linked list.
@@ -106,7 +106,7 @@ void insertTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* 
  * \param head Pointer to the pointer to the head of the linked list.
  * \param tcb Pointer to the task control block to be removed.
  */
-void removeTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* tcb);
+void removeTCB(volatile TaskControlBlock** head, volatile TaskControlBlock* tcb);
 
 /**
  * \brief Update the priority of a task control block in a linked list.
@@ -119,7 +119,7 @@ void removeTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* 
  * \param tcb Pointer to the task control block to be updated.
  * \param priority The new priority for the task control block.
  */
-void updateTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* tcb, uint8_t priority);
+void updateTCB(volatile TaskControlBlock** head, volatile TaskControlBlock* tcb, uint8_t priority);
 
 /**
  * \brief Move a task control block from one linked list to another.
@@ -131,6 +131,6 @@ void updateTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* 
  * \param newHead Pointer to the pointer to the head of the new linked list.
  * \param tcb Pointer to the task control block to be moved.
  */
-void moveTCB(volatile T_TaskControlBlock** currentHead, volatile T_TaskControlBlock** newHead, volatile T_TaskControlBlock* tcb);
+void moveTCB(volatile TaskControlBlock** currentHead, volatile TaskControlBlock** newHead, volatile TaskControlBlock* tcb);
 
 #endif // _TCB_H_

--- a/jocktos/inc/timers.h
+++ b/jocktos/inc/timers.h
@@ -18,6 +18,6 @@
 
 /* -- Function Declarations ----------------------------------------------- */
 
-void SysTick_Configuration(int freq);
+void sysTickConfiguration(int freq);
 
 #endif /* _TIMERS_H_ */

--- a/jocktos/src/allocator.c
+++ b/jocktos/src/allocator.c
@@ -47,15 +47,15 @@ bool getBit(uint16_t* bitmap, uint16_t index);
  * @details
  * This function takes a bitmap representing used blocks, the size of the bitmap, and the number of contiguous blocks needed.
  * It iterates through each bit in the bitmap, keeping track of the count of consecutive free blocks.
- * When it finds a sequence of `numBlocks` consecutive free blocks, it returns the index of the first block in the sequence.
+ * When it finds a sequence of `num_blocks` consecutive free blocks, it returns the index of the first block in the sequence.
  * If it reaches the end of the bitmap without finding a suitable sequence, it returns SIZE_MAX.
  *
+ * @param num_blocks The number of contiguous blocks needed
  * @param used The bitmap representing used blocks
  * @param size The size of the bitmap
- * @param numBlocks The number of contiguous blocks needed
  * @return The index of the first block in the contiguous sequence if found, or UINT16_MAX if not found
  */
-uint16_t findContiguousFreeBlocks(uint16_t* used, uint16_t size, uint16_t numBlocks);
+uint16_t findContiguousFreeBlocks(uint16_t num_blocks, uint16_t* used, uint16_t size);
 
 /* -- Public Functions----------------------------------------------------- */
 
@@ -67,22 +67,22 @@ uint16_t findContiguousFreeBlocks(uint16_t* used, uint16_t size, uint16_t numBlo
  *   is calculated based on the number of blocks that can fit in the provided memory.
  * - The other portion of the memory will be used to store the allocated blocks.
  */
-void initAllocator(Allocator* allocator, void* memory, uint16_t size, uint16_t blockSize) {
+void initAllocator(Allocator* allocator, uint16_t block_size, void* memory, uint16_t size) {
     // Calculate the number of blocks that can fit in the provided memory
-    uint16_t numBlocks = size / blockSize;
+    uint16_t num_blocks = size / block_size;
     // Calculate the size of the bitmap portion of the memory region
-    uint16_t bitmapSize = ((numBlocks + 15) / 16) * 2 * sizeof(uint16_t);
+    uint16_t bitmap_size = ((num_blocks + 15) / 16) * 2 * sizeof(uint16_t);
     // Initialize the allocator with the calculated values
-    allocator->bitmaps.size = (size - bitmapSize) / blockSize;  // Number of blocks in the memory region
+    allocator->bitmaps.size = (size - bitmap_size) / block_size;  // Number of blocks in the memory region
     allocator->bitmaps.used = (uint16_t*)memory;  // Pointer to the used bitmap
     // Adjust the memory pointer to the start of the allocated block portion
-    memory = (void*)((uint8_t*)memory + bitmapSize / 2);
-    allocator->bitmaps.alloc = (uint16_t*)memory;  // Pointer to the allocated bitmap
+    memory = (void*)((uint8_t*)memory + bitmap_size / 2);
+    allocator->bitmaps.heads = (uint16_t*)memory;  // Pointer to the allocated bitmap
     // Adjust the memory pointer to the start of the allocated block portion
-    memory = (void*)((uint8_t*)memory + bitmapSize / 2);
+    memory = (void*)((uint8_t*)memory + bitmap_size / 2);
     allocator->memory.head = memory;  // Pointer to the start of the allocated block portion
-    allocator->memory.size = allocator->bitmaps.size * blockSize;  // Size of the allocated block portion
-    allocator->blockSize = blockSize;  // Size of each block
+    allocator->memory.size = allocator->bitmaps.size * block_size;  // Size of the allocated block portion
+    allocator->block_size = block_size;  // Size of each block
 }
 
 /**
@@ -93,23 +93,21 @@ void initAllocator(Allocator* allocator, void* memory, uint16_t size, uint16_t b
  */
 void* allocate(Allocator* allocator, uint16_t size) {
     // Calculate the number of blocks needed to allocate the requested size
-    uint16_t numBlocks = (size + allocator->blockSize - 1) / allocator->blockSize;
+    uint16_t num_blocks = (size + allocator->block_size - 1) / allocator->block_size;
     // Find the index of the first contiguous free block in the bitmap
-    uint16_t startIndex = findContiguousFreeBlocks(allocator->bitmaps.used, allocator->bitmaps.size, numBlocks);
+    uint16_t start_index = findContiguousFreeBlocks(num_blocks, allocator->bitmaps.used, allocator->bitmaps.size);
     // If no contiguous free blocks are available, return NULL
-    if (startIndex == UINT16_MAX) {
+    if (start_index == UINT16_MAX) {
         return NULL;
     }
     // Mark the allocated blocks as used in the bitmap
-    for (uint16_t i = 0; i < numBlocks; i++) {
-        setBit(allocator->bitmaps.used, startIndex + i);
+    for (uint16_t i = 0; i < num_blocks; i++) {
+        setBit(allocator->bitmaps.used, start_index + i);
     }
     // Mark the allocated blocks as allocated in the bitmap
-    setBit(allocator->bitmaps.alloc, startIndex);
-    // Calculate the pointer to the start of the allocated block
-    void* ptr = (void*)((uint8_t*)allocator->memory.head + startIndex * allocator->blockSize);
-    // Return the pointer to the allocated block
-    return ptr;
+    setBit(allocator->bitmaps.heads, start_index);
+    // Return a pointer to the head of the allocated block
+    return (void*)((uint8_t*)allocator->memory.head + start_index * allocator->block_size);
 }
 
 /**
@@ -121,13 +119,13 @@ void* allocate(Allocator* allocator, uint16_t size) {
  */
 bool deallocate(Allocator* allocator, void* ptr) {
     // Calculate the index of the block in the allocator's memory
-    uint16_t index = ((uint8_t*)ptr - (uint8_t*)allocator->memory.head) / allocator->blockSize;
+    uint16_t index = ((uint8_t*)ptr - (uint8_t*)allocator->memory.head) / allocator->block_size;
     // Check if the block is currently allocated
-    if (!getBit(allocator->bitmaps.alloc, index)) return false;
+    if (!getBit(allocator->bitmaps.heads, index)) return false;
     // Clear the allocated bit for the block
-    clearBit(allocator->bitmaps.alloc, index);
+    clearBit(allocator->bitmaps.heads, index);
     // Traverse the bitmap, clearing the used bits for all blocks in the sequence
-    while (getBit(allocator->bitmaps.used, index) && !getBit(allocator->bitmaps.alloc, index)) {
+    while (getBit(allocator->bitmaps.used, index) && !getBit(allocator->bitmaps.heads, index)) {
         clearBit(allocator->bitmaps.used, index++);
         // Break if we reach the end of the bitmap
         if (index >= allocator->bitmaps.size) break;
@@ -137,13 +135,13 @@ bool deallocate(Allocator* allocator, void* ptr) {
 
 /* -- Private Functions --------------------------------------------------- */
 
-uint16_t findContiguousFreeBlocks(uint16_t* used, uint16_t size, uint16_t numBlocks) {
+uint16_t findContiguousFreeBlocks(uint16_t num_blocks, uint16_t* used, uint16_t size) {
     uint16_t count = 0; // Initialize a counter to track consecutive free blocks
     for (uint16_t i = 0; i < size; i++) { // Iterate through each bit in the bitmap
         if (!getBit(used, i)) { // If the bit is not set (i.e., the block is free)
             count++; // Increment the counter
-            if (count == numBlocks) { // If the counter equals the number of blocks needed
-                return i - numBlocks + 1; // Return the starting index of the sequence
+            if (count == num_blocks) { // If the counter equals the number of blocks needed
+                return i - num_blocks + 1; // Return the starting index of the sequence
             }
         } else { // If the bit is set (i.e., the block is used)
             count = 0; // Reset the counter

--- a/jocktos/src/main.c
+++ b/jocktos/src/main.c
@@ -33,7 +33,7 @@ int main(void)
     TestArgStruct test_val = {.value = 1234, .ID = "Test Val!\n"};
 
     TaskControlBlock testTask = TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=512,
+        .stackSize_By=512,
         .taskFunct=testArgsTask,
         .taskArg=(void*)&test_val,
         .name="test args");
@@ -41,7 +41,7 @@ int main(void)
 
     /* Sample Sleep Task */
     TaskControlBlock sleepTask = TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=512, 
+        .stackSize_By=512, 
         .taskFunct=sleepTest,
         .name="sleep test");
     createTask(&sleepTask);

--- a/jocktos/src/main.c
+++ b/jocktos/src/main.c
@@ -27,7 +27,7 @@ int main(void)
         .allocatorBlockSize = 256
     );
     /* Configures JOCKTOS Kernel with Default structure */
-    configureJOCKTOS(&config);
+    jock_configure(&config);
     
     /* Sample Task Employing passing in a task argument of anytype */
     TestArgStruct test_val = {.value = 1234, .ID = "Test Val!\n"};
@@ -37,31 +37,31 @@ int main(void)
         .taskFunct=testArgsTask,
         .taskArg=(void*)&test_val,
         .name="test args");
-    createTask(&testTask);
+    jock_createTask(&testTask);
 
     /* Sample Sleep Task */
     TaskControlBlock sleepTask = TASKCONTROLBLOCK_DEF(
         .stackSize_By=512, 
         .taskFunct=sleepTest,
         .name="sleep test");
-    createTask(&sleepTask);
+    jock_createTask(&sleepTask);
 
     /* Sample Semaphore Task */
     TaskControlBlock lockTask = TASKCONTROLBLOCK_DEF(
         .stackSize_By=512,
         .taskFunct=mutexTestTask,
         .name="semaphore test");
-    createTask(&lockTask);
+    jock_createTask(&lockTask);
 
     /* Sample Task Monitor Stack Test Task */
     TaskControlBlock stackTask = TASKCONTROLBLOCK_DEF(
         .stackSize_By=512,
         .taskFunct=stackInflationTestTask,
         .name="stack inflation");
-    createTask(&stackTask);
+    jock_createTask(&stackTask);
 
     /* This will start the scheduler and tasking system */
-    runJOCKTOS();
+    jock_run();
 
     int x = 100;
     int y = 0;
@@ -86,10 +86,10 @@ void testArgsTask(void* arg) {
 
 void sleepTest(void* arg) {
     while (true) {
-        takeSemaphore(&testMutex);
-        sleep(1000);
-        giveSemaphore(&testMutex);
-        sleep(1000);
+        jock_takeSemaphore(&testMutex);
+        jock_sleep(1000);
+        jock_giveSemaphore(&testMutex);
+        jock_sleep(1000);
     }
 }
 
@@ -98,10 +98,10 @@ void mutexTestTask(void* arg) {
     while(1) {
         x--;
         if (x == 5000) {
-            takeSemaphore(&testMutex);
+            jock_takeSemaphore(&testMutex);
         }
         if (x == 0) {
-            giveSemaphore(&testMutex);
+            jock_giveSemaphore(&testMutex);
             x = 10000;
         }
     }

--- a/jocktos/src/main.c
+++ b/jocktos/src/main.c
@@ -10,7 +10,7 @@
 /* -- Local Globals (not for libraries with application instantiation) ---- */
 
 extern Scheduler JOCKTOSScheduler; ///<  Used for debugging (include in Watch List)
-Semaphore testMutex = SEMAPHORE_DEF();
+Semaphore test_mutex = SEMAPHORE_DEF();
 
 /* -- Functions----------------------------------------------------------- */
 /**
@@ -21,42 +21,42 @@ int main(void)
 {
     /* Configuration Default for the Allocator and option for kernel servicing and monitoring */
     JocktosConfig config = JOCKTOSCONFIG_DEF(
-        .enableIdle = true,
-        .enableMain = true,
-        .enableMonitor = true,
-        .allocatorBlockSize = 256
+        .enable_idle = true,
+        .enable_main = true,
+        .enable_monitor = true,
+        .allocator_block_size = 256
     );
     /* Configures JOCKTOS Kernel with Default structure */
     jock_configure(&config);
     
     /* Sample Task Employing passing in a task argument of anytype */
-    TestArgStruct test_val = {.value = 1234, .ID = "Test Val!\n"};
+    TestArgStruct test_val = {.value = 1234, .id = "Test Val!\n"};
 
     TaskControlBlock testTask = TASKCONTROLBLOCK_DEF(
-        .stackSize_By=512,
-        .taskFunct=testArgsTask,
-        .taskArg=(void*)&test_val,
+        .stack_size_bytes=512,
+        .task_handle=testArgsTask,
+        .task_arg=(void*)&test_val,
         .name="test args");
     jock_createTask(&testTask);
 
     /* Sample Sleep Task */
     TaskControlBlock sleepTask = TASKCONTROLBLOCK_DEF(
-        .stackSize_By=512, 
-        .taskFunct=sleepTest,
+        .stack_size_bytes=512, 
+        .task_handle=sleepTest,
         .name="sleep test");
     jock_createTask(&sleepTask);
 
     /* Sample Semaphore Task */
     TaskControlBlock lockTask = TASKCONTROLBLOCK_DEF(
-        .stackSize_By=512,
-        .taskFunct=mutexTestTask,
+        .stack_size_bytes=512,
+        .task_handle=mutexTestTask,
         .name="semaphore test");
     jock_createTask(&lockTask);
 
     /* Sample Task Monitor Stack Test Task */
     TaskControlBlock stackTask = TASKCONTROLBLOCK_DEF(
-        .stackSize_By=512,
-        .taskFunct=stackInflationTestTask,
+        .stack_size_bytes=512,
+        .task_handle=stackInflationTestTask,
         .name="stack inflation");
     jock_createTask(&stackTask);
 
@@ -86,9 +86,9 @@ void testArgsTask(void* arg) {
 
 void sleepTest(void* arg) {
     while (true) {
-        jock_takeSemaphore(&testMutex);
+        jock_takeSemaphore(&test_mutex);
         jock_sleep(1000);
-        jock_giveSemaphore(&testMutex);
+        jock_giveSemaphore(&test_mutex);
         jock_sleep(1000);
     }
 }
@@ -98,10 +98,10 @@ void mutexTestTask(void* arg) {
     while(1) {
         x--;
         if (x == 5000) {
-            jock_takeSemaphore(&testMutex);
+            jock_takeSemaphore(&test_mutex);
         }
         if (x == 0) {
-            jock_giveSemaphore(&testMutex);
+            jock_giveSemaphore(&test_mutex);
             x = 10000;
         }
     }
@@ -117,14 +117,14 @@ int burnCycles(int cycles) {
 }
 
 int inflateStack(int depth, int cycles) {
-    int localVar = 0;  // This variable will occupy space on the stack
+    int local_var = 0;  // This variable will occupy space on the stack
 
     if (depth > 0) {
-        localVar = burnCycles(cycles);  // Burn cycles before making the recursive call
-        localVar = inflateStack(depth - 1, cycles);  // Recursive call to inflate the stack further
+        local_var = burnCycles(cycles);  // Burn cycles before making the recursive call
+        local_var = inflateStack(depth - 1, cycles);  // Recursive call to inflate the stack further
     } 
-    localVar = burnCycles(cycles);  // Burn cycles once the maximum depth is reached
-    return localVar;
+    local_var = burnCycles(cycles);  // Burn cycles once the maximum depth is reached
+    return local_var;
 }
 
 void stackInflationTestTask(void* arg) {

--- a/jocktos/src/main.c
+++ b/jocktos/src/main.c
@@ -9,8 +9,8 @@
 
 /* -- Local Globals (not for libraries with application instantiation) ---- */
 
-extern T_Scheduler JOCKTOSScheduler; ///<  Used for debugging (include in Watch List)
-T_Semaphore testMutex = T_SEMAPHORE_DEF();
+extern Scheduler JOCKTOSScheduler; ///<  Used for debugging (include in Watch List)
+Semaphore testMutex = SEMAPHORE_DEF();
 
 /* -- Functions----------------------------------------------------------- */
 /**
@@ -20,7 +20,7 @@ T_Semaphore testMutex = T_SEMAPHORE_DEF();
 int main(void)
 {
     /* Configuration Default for the Allocator and option for kernel servicing and monitoring */
-    T_JocktosConfig config = T_JOCKTOSCONFIG_DEF(
+    JocktosConfig config = JOCKTOSCONFIG_DEF(
         .enableIdle = true,
         .enableMain = true,
         .enableMonitor = true,
@@ -31,32 +31,32 @@ int main(void)
     
     /* Sample Task Employing passing in a task argument of anytype */
     TestArgStruct test_val = {.value = 1234, .ID = "Test Val!\n"};
-    T_TaskControlBlock testTask = T_TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=256, 
+    TaskControlBlock testTask = TASKCONTROLBLOCK_DEF(
+        .stackSize_By=256, 
         .taskFunct=testArgsTask,
         .taskArg=(void*)&test_val,
-        .u8Name="test args");
+        .name="test args");
     createTask(&testTask);
 
     /* Sample Sleep Task */
-    T_TaskControlBlock sleepTask = T_TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=256, 
+    TaskControlBlock sleepTask = TASKCONTROLBLOCK_DEF(
+        .stackSize_By=256, 
         .taskFunct=sleepTest,
-        .u8Name="sleep test");
+        .name="sleep test");
     createTask(&sleepTask);
 
     /* Sample Semaphore Task */
-    T_TaskControlBlock lockTask = T_TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=256, 
+    TaskControlBlock lockTask = TASKCONTROLBLOCK_DEF(
+        .stackSize_By=256, 
         .taskFunct=mutexTestTask,
-        .u8Name="semaphore test");
+        .name="semaphore test");
     createTask(&lockTask);
 
     /* Sample Task Monitor Stack Test Task */
-    T_TaskControlBlock stackTask = T_TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=256, 
+    TaskControlBlock stackTask = TASKCONTROLBLOCK_DEF(
+        .stackSize_By=256, 
         .taskFunct=stackInflationTestTask,
-        .u8Name="stack inflation");
+        .name="stack inflation");
     createTask(&stackTask);
 
     /* This will start the scheduler and tasking system */

--- a/jocktos/src/os.c
+++ b/jocktos/src/os.c
@@ -28,9 +28,9 @@
  * 
  * \param tcb Pointer to task control block to be monitored.
  */
-static inline void monitorStackUsage(volatile T_TaskControlBlock** tcb) {
-    (*tcb)->stackUsage = 100.0 * (1.0 - ((double)((*tcb)->u32TaskStackPointer \
-    - (*tcb)->u32TaskStackOverflow)) / (double)((*tcb)->u32StackSize_By * sizeof(uintptr_t)));
+static inline void monitorStackUsage(volatile TaskControlBlock** tcb) {
+    (*tcb)->stackUsage = 100.0 * (1.0 - ((double)((*tcb)->taskStackPointer \
+    - (*tcb)->taskStackOverflow)) / (double)((*tcb)->stackSize_By * sizeof(uintptr_t)));
 }
 
 /**
@@ -40,9 +40,9 @@ static inline void monitorStackUsage(volatile T_TaskControlBlock** tcb) {
  * It also sets the program counter (PC) to the task function handle, the link register (LR) to a specific value, and the stack pointer (SP) to the bottom of the stack range.
  * After setting up the initial stack frame, the function fills the remaining unused stack space with a known value and sets the top 8 bytes to another known value.
  *
- * @param tcb Pointer to a T_TaskControlBlock structure representing the task.
+ * @param tcb Pointer to a TaskControlBlock structure representing the task.
  */
-void initializeStack(T_TaskControlBlock* tcb);
+void initializeStack(TaskControlBlock* tcb);
 
 /**
 * \brief pre defined OS task for idle.
@@ -60,34 +60,34 @@ void monitorJOCKTOS(void* arg);
 /* -- Local Globals (not for libraries with application instantiation) ---- */
 
 static Allocator allocator;
-T_Scheduler JOCKTOSScheduler = {false, 0, NULL, NULL, NULL};
-extern T_TCBError JOCKTOS_TCBError;
+Scheduler JOCKTOSScheduler = {false, 0, NULL, NULL, NULL};
+extern TCBError JOCKTOS_TCBError;
 
-T_TaskControlBlock userMainControlBlock = T_TASKCONTROLBLOCK_DEF(
+TaskControlBlock userMainControlBlock = TASKCONTROLBLOCK_DEF(
         .taskFunct=NULL,
-        .u8Name="user space `main`");
+        .name="user space `main`");
 
-T_TaskControlBlock stackUsageMonitor = T_TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=1024, 
+TaskControlBlock stackUsageMonitor = TASKCONTROLBLOCK_DEF(
+        .stackSize_By=1024, 
         .taskFunct=monitorJOCKTOS,
-        .u8Name="stack usage monitor");
+        .name="stack usage monitor");
 
-T_TaskControlBlock defaultOSIdle = T_TASKCONTROLBLOCK_DEF(
-        .u32StackSize_By=256, 
+TaskControlBlock defaultOSIdle = TASKCONTROLBLOCK_DEF(
+        .stackSize_By=256, 
         .taskFunct=idleJOCKTOS,
-        .u8Name="default OS idle task");
+        .name="default OS idle task");
 
 /* -- Public Functions----------------------------------------------------- */
 
-void createTask(T_TaskControlBlock* tcb) {
+void createTask(TaskControlBlock* tcb) {
     // check if task function handle is valid
     if (!tcb->taskFunct) {
         // TODO: better error handling
         JOCKTOS_TCBError.invalidTaskHandle++;
         return;
     }
-    tcb->u32TaskStackOverflow = (uintptr_t*)allocate(&allocator, tcb->u32StackSize_By * sizeof(uintptr_t));
-    if (!tcb->u32TaskStackOverflow) {
+    tcb->taskStackOverflow = (uintptr_t*)allocate(&allocator, tcb->stackSize_By * sizeof(uintptr_t));
+    if (!tcb->taskStackOverflow) {
         // TODO: better error handling
         JOCKTOS_TCBError.failedToAllocate++;
         return;
@@ -96,8 +96,8 @@ void createTask(T_TaskControlBlock* tcb) {
     insertTCB(&JOCKTOSScheduler.ready, tcb);
 }
 
-void switchRunningTask(volatile T_TaskControlBlock** head) {
-    volatile T_TaskControlBlock* suspended = NULL;
+void switchRunningTask(volatile TaskControlBlock** head) {
+    volatile TaskControlBlock* suspended = NULL;
     if (JOCKTOSScheduler.pending) return;
     JOCKTOSScheduler.pending = true;
     if (JOCKTOSScheduler.running) {
@@ -105,16 +105,16 @@ void switchRunningTask(volatile T_TaskControlBlock** head) {
     }
     suspended = JOCKTOSScheduler.suspended;
     while (suspended != NULL) {
-        if (currentTime() >= suspended->u32Delay) {
+        if (currentTime() >= suspended->delay) {
             moveTCB(&JOCKTOSScheduler.suspended, &JOCKTOSScheduler.ready, suspended);
-            suspended->eState = eREADY;
+            suspended->state = READY;
         }
         suspended = suspended->TCBNext;
     }
     TRIGGER_PendSV;
 }
 
-void configureJOCKTOS(T_JocktosConfig* config) {
+void configureJOCKTOS(JocktosConfig* config) {
     void* memory = calloc(ALLOCATOR_SIZE, 1);
     initAllocator(&allocator, memory, ALLOCATOR_SIZE, config->allocatorBlockSize);
     if (config->enableMonitor) createTask(&stackUsageMonitor);
@@ -141,10 +141,10 @@ void runJOCKTOS(void) {
 
 /* -- Private Functions --------------------------------------------------- */
 
-void initializeStack(T_TaskControlBlock* tcb) {
-    uintptr_t* taskStack = tcb->u32TaskStackOverflow;
+void initializeStack(TaskControlBlock* tcb) {
+    uintptr_t* taskStack = tcb->taskStackOverflow;
     // set intermediate stack pointer to bottom of range
-    taskStack = (uintptr_t*)(taskStack + ((tcb->u32StackSize_By) / 8) * 8);
+    taskStack = (uintptr_t*)(taskStack + ((tcb->stackSize_By) / 8) * 8);
     // define tasks initial exception return stack
     uintptr_t* initStackPtr;
     //  - non-critical registers are initialized to their index
@@ -167,12 +167,12 @@ void initializeStack(T_TaskControlBlock* tcb) {
     *(--taskStack) = 0x00000006U;               ///<   Set R6  register deafult to its index
     *(--taskStack) = 0x00000005U;               ///<   Set R5  register deafult to its index
     *(--taskStack) = 0x00000004U;               ///<   Set R4  register deafult to its index
-    tcb->u32TaskStackPointer = taskStack;
+    tcb->taskStackPointer = taskStack;
     // Fill unused process stack with known value
-    while (taskStack > tcb->u32TaskStackOverflow + 8) {
+    while (taskStack > tcb->taskStackOverflow + 8) {
         *(--taskStack) = 0xBABEFACEU;
     }
-    while (taskStack > tcb->u32TaskStackOverflow) {
+    while (taskStack > tcb->taskStackOverflow) {
         *(--taskStack) = 0xDEADBEEFU; ///< set top 8 bytes to something else
     }
 }
@@ -192,18 +192,18 @@ void PendSV_Handler(void) {
         __asm volatile ("mrs r0, msp"); // TODO: figure out how to use PSP instead
         // __asm volatile ("mrs r0, psp");
         __asm volatile ("stmdb r0!, {r4-r11}");
-        __asm volatile ("mov %0, r0" : "=r" (JOCKTOSScheduler.running->u32TaskStackPointer) :: );
+        __asm volatile ("mov %0, r0" : "=r" (JOCKTOSScheduler.running->taskStackPointer) :: );
         // --------------------------------------------------------------------------------------
     }
     // pop off of ready task list into running
     JOCKTOSScheduler.running = JOCKTOSScheduler.ready;
     JOCKTOSScheduler.ready = JOCKTOSScheduler.ready->TCBNext;
     JOCKTOSScheduler.running->TCBNext = NULL;
-    JOCKTOSScheduler.running->eState = eRUNNING;
+    JOCKTOSScheduler.running->state = RUNNING;
     JOCKTOSScheduler.pending = false;
     // ------------------------------------------------------------------------------------------
     // pop additional registers from the new process stack and load new process stack pointer
-    __asm volatile ("mov r0, %0" : : "r" (JOCKTOSScheduler.running->u32TaskStackPointer) : "r0");
+    __asm volatile ("mov r0, %0" : : "r" (JOCKTOSScheduler.running->taskStackPointer) : "r0");
     __asm volatile ("ldmia r0!, {r4-r11}");
     __asm volatile ("msr msp, r0"); // TODO: figure out how to use PSP instead
     // __asm volatile ("msr psp, r0"); // TODO: figure out how to use PSP instead
@@ -213,23 +213,23 @@ void PendSV_Handler(void) {
 }
 
 void monitorJOCKTOS(void* arg) {
-    volatile T_TaskControlBlock* head = NULL;
-    E_TaskState monitorScope = eRUNNING;
+    volatile TaskControlBlock* head = NULL;
+    TaskState monitorScope = RUNNING;
     while(true) {
         switch (monitorScope) {
-            case eREADY: {
+            case READY: {
                 head = JOCKTOSScheduler.ready;
-                monitorScope = eRUNNING;
+                monitorScope = RUNNING;
                 break;
             }
-            case eRUNNING: {
+            case RUNNING: {
                 head = JOCKTOSScheduler.running;
-                monitorScope = eSUSPENDED;
+                monitorScope = SUSPENDED;
                 break;
             }
             default: {
                 head = JOCKTOSScheduler.suspended;
-                monitorScope = eREADY;
+                monitorScope = READY;
                 break;
             }
         }

--- a/jocktos/src/os.c
+++ b/jocktos/src/os.c
@@ -50,12 +50,12 @@ void initializeStack(TaskControlBlock* tcb);
 * Infinite while loop.
 * TODO: Figure out how to low power sleep without disabling ISR's
 */
-void idleJOCKTOS(void* arg);
+void idleTask(void* arg);
 
 /**
  * \brief pre defined OS task to monitor stack usage
  */
-void monitorJOCKTOS(void* arg);
+void monitorTask(void* arg);
 
 /* -- Local Globals (not for libraries with application instantiation) ---- */
 
@@ -69,17 +69,17 @@ TaskControlBlock userMainControlBlock = TASKCONTROLBLOCK_DEF(
 
 TaskControlBlock stackUsageMonitor = TASKCONTROLBLOCK_DEF(
         .stackSize_By=1024, 
-        .taskFunct=monitorJOCKTOS,
+        .taskFunct=monitorTask,
         .name="stack usage monitor");
 
 TaskControlBlock defaultOSIdle = TASKCONTROLBLOCK_DEF(
         .stackSize_By=512,
-        .taskFunct=idleJOCKTOS,
+        .taskFunct=idleTask,
         .name="default OS idle task");
 
 /* -- Public Functions----------------------------------------------------- */
 
-void createTask(TaskControlBlock* tcb) {
+void jock_createTask(TaskControlBlock* tcb) {
     // check if task function handle is valid
     if (!tcb->taskFunct) {
         // TODO: better error handling
@@ -105,7 +105,7 @@ void switchRunningTask(volatile TaskControlBlock** head) {
     }
     suspended = JOCKTOSScheduler.suspended;
     while (suspended != NULL) {
-        if (currentTime() >= suspended->delay) {
+        if (jock_currentTime() >= suspended->delay) {
             moveTCB(&JOCKTOSScheduler.suspended, &JOCKTOSScheduler.ready, suspended);
             suspended->state = READY;
         }
@@ -114,15 +114,15 @@ void switchRunningTask(volatile TaskControlBlock** head) {
     TRIGGER_PendSV;
 }
 
-void configureJOCKTOS(JocktosConfig* config) {
+void jock_configure(JocktosConfig* config) {
     void* memory = calloc(ALLOCATOR_SIZE, sizeof(uint8_t));
     initAllocator(&allocator, memory, ALLOCATOR_SIZE, config->allocatorBlockSize);
-    if (config->enableMonitor) createTask(&stackUsageMonitor);
+    if (config->enableMonitor) jock_createTask(&stackUsageMonitor);
     if (config->enableMain) insertTCB(&JOCKTOSScheduler.running, &userMainControlBlock);
-    if (config->enableIdle || (!config->enableMonitor && !config->enableMain)) createTask(&defaultOSIdle);
+    if (config->enableIdle || (!config->enableMonitor && !config->enableMain)) jock_createTask(&defaultOSIdle);
 }
 
-void runJOCKTOS(void) {
+void jock_run(void) {
     // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     /** failed attempt to utilize PSP Thread Mode
     uint32_t initPSP;
@@ -212,7 +212,7 @@ void PendSV_Handler(void) {
     __asm volatile ("cpsie i" : : : "memory");
 }
 
-void monitorJOCKTOS(void* arg) {
+void monitorTask(void* arg) {
     volatile TaskControlBlock* head = NULL;
     TaskState monitorScope = RUNNING;
     while(true) {
@@ -240,7 +240,7 @@ void monitorJOCKTOS(void* arg) {
     }
 }
 
-void idleJOCKTOS(void* arg) {
+void idleTask(void* arg) {
     while(true) {}
     // TODO: Figure out how to low power
 }

--- a/jocktos/src/os.c
+++ b/jocktos/src/os.c
@@ -24,13 +24,13 @@
 /* -- Private Function Declarations --------------------------------------- */
 
 /**
- * \brief Updates the task control blocks stackUsage
+ * \brief Updates the task control blocks stack_usage
  * 
  * \param tcb Pointer to task control block to be monitored.
  */
 static inline void monitorStackUsage(volatile TaskControlBlock** tcb) {
-    (*tcb)->stackUsage = 100.0 * (1.0 - ((double)((*tcb)->taskStackPointer \
-    - (*tcb)->taskStackOverflow)) / (double)((*tcb)->stackSize_By * sizeof(uintptr_t)));
+    (*tcb)->stack_usage = 100.0 * (1.0 - ((double)((*tcb)->stack_pointer \
+    - (*tcb)->stack_overflow)) / (double)((*tcb)->stack_size_bytes * sizeof(uintptr_t)));
 }
 
 /**
@@ -63,33 +63,33 @@ static Allocator allocator;
 Scheduler JOCKTOSScheduler = {false, 0, NULL, NULL, NULL};
 extern TCBError JOCKTOS_TCBError;
 
-TaskControlBlock userMainControlBlock = TASKCONTROLBLOCK_DEF(
-        .taskFunct=NULL,
+TaskControlBlock usr_main_tcb = TASKCONTROLBLOCK_DEF(
+        .task_handle=NULL,
         .name="user space `main`");
 
-TaskControlBlock stackUsageMonitor = TASKCONTROLBLOCK_DEF(
-        .stackSize_By=1024, 
-        .taskFunct=monitorTask,
+TaskControlBlock stack_monitor_tcb = TASKCONTROLBLOCK_DEF(
+        .stack_size_bytes=1024, 
+        .task_handle=monitorTask,
         .name="stack usage monitor");
 
-TaskControlBlock defaultOSIdle = TASKCONTROLBLOCK_DEF(
-        .stackSize_By=512,
-        .taskFunct=idleTask,
+TaskControlBlock idle_tcb = TASKCONTROLBLOCK_DEF(
+        .stack_size_bytes=512,
+        .task_handle=idleTask,
         .name="default OS idle task");
 
 /* -- Public Functions----------------------------------------------------- */
 
 void jock_createTask(TaskControlBlock* tcb) {
     // check if task function handle is valid
-    if (!tcb->taskFunct) {
+    if (!tcb->task_handle) {
         // TODO: better error handling
-        JOCKTOS_TCBError.invalidTaskHandle++;
+        JOCKTOS_TCBError.invalid_task_handle++;
         return;
     }
-    tcb->taskStackOverflow = (uintptr_t*)allocate(&allocator, tcb->stackSize_By);
-    if (!tcb->taskStackOverflow) {
+    tcb->stack_overflow = (uintptr_t*)allocate(&allocator, tcb->stack_size_bytes);
+    if (!tcb->stack_overflow) {
         // TODO: better error handling
-        JOCKTOS_TCBError.failedToAllocate++;
+        JOCKTOS_TCBError.failed_to_allocate++;
         return;
     }
     initializeStack(tcb);
@@ -105,21 +105,21 @@ void switchRunningTask(volatile TaskControlBlock** head) {
     }
     suspended = JOCKTOSScheduler.suspended;
     while (suspended != NULL) {
-        if (jock_currentTime() >= suspended->delay) {
-            moveTCB(&JOCKTOSScheduler.suspended, &JOCKTOSScheduler.ready, suspended);
+        if (jock_currentTime() >= suspended->delay_ms) {
+            moveTCB(&JOCKTOSScheduler.suspended, suspended, &JOCKTOSScheduler.ready);
             suspended->state = READY;
         }
-        suspended = suspended->TCBNext;
+        suspended = suspended->next;
     }
     TRIGGER_PendSV;
 }
 
 void jock_configure(JocktosConfig* config) {
     void* memory = calloc(ALLOCATOR_SIZE, sizeof(uint8_t));
-    initAllocator(&allocator, memory, ALLOCATOR_SIZE, config->allocatorBlockSize);
-    if (config->enableMonitor) jock_createTask(&stackUsageMonitor);
-    if (config->enableMain) insertTCB(&JOCKTOSScheduler.running, &userMainControlBlock);
-    if (config->enableIdle || (!config->enableMonitor && !config->enableMain)) jock_createTask(&defaultOSIdle);
+    initAllocator(&allocator, config->allocator_block_size, memory, ALLOCATOR_SIZE);
+    if (config->enable_monitor) jock_createTask(&stack_monitor_tcb);
+    if (config->enable_main) insertTCB(&JOCKTOSScheduler.running, &usr_main_tcb);
+    if (config->enable_idle || (!config->enable_monitor && !config->enable_main)) jock_createTask(&idle_tcb);
 }
 
 void jock_run(void) {
@@ -135,51 +135,51 @@ void jock_run(void) {
     // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     NVIC_SetPriority(PendSV_IRQn, 0xFFU);
     // Configure SysTick to generate an interrupt every 1 ms 
-    SysTick_Configuration(127); // TODO: where tf does 127 come from...
+    sysTickConfiguration(127); // TODO: where tf does 127 come from...
     NVIC_SetPriority(SysTick_IRQn, 0U);
 }
 
 /* -- Private Functions --------------------------------------------------- */
 
 void initializeStack(TaskControlBlock* tcb) {
-    uintptr_t* taskStack = tcb->taskStackOverflow;
+    uintptr_t* stack_ptr = tcb->stack_overflow;
     // set intermediate stack pointer to bottom of range
-    taskStack = (uintptr_t*)(taskStack + tcb->stackSize_By / sizeof(uintptr_t));
+    stack_ptr = (uintptr_t*)(stack_ptr + tcb->stack_size_bytes / sizeof(uintptr_t));
     // define tasks initial exception return stack
-    uintptr_t* initStackPtr;
+    uintptr_t* init_stack_ptr;
     //  - non-critical registers are initialized to their index
-    *(--taskStack) = (1U << 24);                ///<   Set thumb state bit in EPSR
-    *(--taskStack) = (uintptr_t)tcb->taskFunct; ///<   Set PC to task function handle
-    *(--taskStack) = 0xFFFFFFF9U;               ///<   Set LR  register for MSP thread mode
-    // *(--taskStack) = 0xFFFFFFFDU;               ///<   Set LR  register for PSP thread mode
-    *(--taskStack) = 0x0000000CU;               ///<   Set R12 register deafult to its index
-    *(--taskStack) = 0x00000003U;               ///<   Set R3  register deafult to its index
-    *(--taskStack) = 0x00000002U;               ///<   Set R2  register deafult to its index
-    *(--taskStack) = 0x00000001U;               ///<   Set R1  register deafult to its index
-    *(--taskStack) = (uintptr_t)tcb->taskArg;   ///<   Set R0  register to the argument for the tasks function
-    initStackPtr = taskStack - 1;               ///<   Catch top of initial post-exception stack
-    *(--taskStack) = (uintptr_t)initStackPtr;   ///<   ISR push / pop "working stack pointer" as R7
-    *(--taskStack) = 0x0000000BU;               ///<   Set R11 register deafult to its index
-    *(--taskStack) = 0x0000000AU;               ///<   Set R10 register deafult to its index
-    *(--taskStack) = 0x00000009U;               ///<   Set R9  register deafult to its index
-    *(--taskStack) = 0x00000008U;               ///<   Set R8  register deafult to its index
-    *(--taskStack) = (uintptr_t)initStackPtr;   ///<   Set R7 to "working stack pointer"
-    *(--taskStack) = 0x00000006U;               ///<   Set R6  register deafult to its index
-    *(--taskStack) = 0x00000005U;               ///<   Set R5  register deafult to its index
-    *(--taskStack) = 0x00000004U;               ///<   Set R4  register deafult to its index
-    tcb->taskStackPointer = taskStack;
+    *(--stack_ptr) = (1U << 24);                ///<   Set thumb state bit in EPSR
+    *(--stack_ptr) = (uintptr_t)tcb->task_handle; ///<   Set PC to task function handle
+    *(--stack_ptr) = 0xFFFFFFF9U;               ///<   Set LR  register for MSP thread mode
+    // *(--stack_ptr) = 0xFFFFFFFDU;               ///<   Set LR  register for PSP thread mode
+    *(--stack_ptr) = 0x0000000CU;               ///<   Set R12 register deafult to its index
+    *(--stack_ptr) = 0x00000003U;               ///<   Set R3  register deafult to its index
+    *(--stack_ptr) = 0x00000002U;               ///<   Set R2  register deafult to its index
+    *(--stack_ptr) = 0x00000001U;               ///<   Set R1  register deafult to its index
+    *(--stack_ptr) = (uintptr_t)tcb->task_arg;   ///<   Set R0  register to the argument for the tasks function
+    init_stack_ptr = stack_ptr - 1;               ///<   Catch top of initial post-exception stack
+    *(--stack_ptr) = (uintptr_t)init_stack_ptr;   ///<   ISR push / pop "working stack pointer" as R7
+    *(--stack_ptr) = 0x0000000BU;               ///<   Set R11 register deafult to its index
+    *(--stack_ptr) = 0x0000000AU;               ///<   Set R10 register deafult to its index
+    *(--stack_ptr) = 0x00000009U;               ///<   Set R9  register deafult to its index
+    *(--stack_ptr) = 0x00000008U;               ///<   Set R8  register deafult to its index
+    *(--stack_ptr) = (uintptr_t)init_stack_ptr;   ///<   Set R7 to "working stack pointer"
+    *(--stack_ptr) = 0x00000006U;               ///<   Set R6  register deafult to its index
+    *(--stack_ptr) = 0x00000005U;               ///<   Set R5  register deafult to its index
+    *(--stack_ptr) = 0x00000004U;               ///<   Set R4  register deafult to its index
+    tcb->stack_pointer = stack_ptr;
     // Fill unused process stack with known value
-    while (taskStack > tcb->taskStackOverflow + 8) {
-        *(--taskStack) = 0xBABEFACEU;
+    while (stack_ptr > tcb->stack_overflow + 8) {
+        *(--stack_ptr) = 0xBABEFACEU;
     }
-    while (taskStack > tcb->taskStackOverflow) {
-        *(--taskStack) = 0xDEADBEEFU; ///< set top 8 bytes to something else
+    while (stack_ptr > tcb->stack_overflow) {
+        *(--stack_ptr) = 0xDEADBEEFU; ///< set top 8 bytes to something else
     }
 }
 
 void SysTick_Handler(void) {
     __asm volatile ("cpsid i" : : : "memory");
-    JOCKTOSScheduler.tickCount++;
+    JOCKTOSScheduler.tick_count++;
     switchRunningTask(&JOCKTOSScheduler.ready);
    __asm volatile ("cpsie i" : : : "memory");
 }
@@ -192,18 +192,18 @@ void PendSV_Handler(void) {
         __asm volatile ("mrs r0, msp"); // TODO: figure out how to use PSP instead
         // __asm volatile ("mrs r0, psp");
         __asm volatile ("stmdb r0!, {r4-r11}");
-        __asm volatile ("mov %0, r0" : "=r" (JOCKTOSScheduler.running->taskStackPointer) :: );
+        __asm volatile ("mov %0, r0" : "=r" (JOCKTOSScheduler.running->stack_pointer) :: );
         // --------------------------------------------------------------------------------------
     }
     // pop off of ready task list into running
     JOCKTOSScheduler.running = JOCKTOSScheduler.ready;
-    JOCKTOSScheduler.ready = JOCKTOSScheduler.ready->TCBNext;
-    JOCKTOSScheduler.running->TCBNext = NULL;
+    JOCKTOSScheduler.ready = JOCKTOSScheduler.ready->next;
+    JOCKTOSScheduler.running->next = NULL;
     JOCKTOSScheduler.running->state = RUNNING;
     JOCKTOSScheduler.pending = false;
     // ------------------------------------------------------------------------------------------
     // pop additional registers from the new process stack and load new process stack pointer
-    __asm volatile ("mov r0, %0" : : "r" (JOCKTOSScheduler.running->taskStackPointer) : "r0");
+    __asm volatile ("mov r0, %0" : : "r" (JOCKTOSScheduler.running->stack_pointer) : "r0");
     __asm volatile ("ldmia r0!, {r4-r11}");
     __asm volatile ("msr msp, r0"); // TODO: figure out how to use PSP instead
     // __asm volatile ("msr psp, r0"); // TODO: figure out how to use PSP instead
@@ -214,28 +214,28 @@ void PendSV_Handler(void) {
 
 void monitorTask(void* arg) {
     volatile TaskControlBlock* head = NULL;
-    TaskState monitorScope = RUNNING;
+    TaskState monitor_scope = RUNNING;
     while(true) {
-        switch (monitorScope) {
+        switch (monitor_scope) {
             case READY: {
                 head = JOCKTOSScheduler.ready;
-                monitorScope = RUNNING;
+                monitor_scope = RUNNING;
                 break;
             }
             case RUNNING: {
                 head = JOCKTOSScheduler.running;
-                monitorScope = SUSPENDED;
+                monitor_scope = SUSPENDED;
                 break;
             }
             default: {
                 head = JOCKTOSScheduler.suspended;
-                monitorScope = READY;
+                monitor_scope = READY;
                 break;
             }
         }
         while(head != NULL) {
             monitorStackUsage(&head);
-            head = head->TCBNext;
+            head = head->next;
         }
     }
 }

--- a/jocktos/src/synchro.c
+++ b/jocktos/src/synchro.c
@@ -16,15 +16,15 @@
 
 /* -- Local Globals (not for libraries with application instantiation) ---- */
 
-extern T_Scheduler JOCKTOSScheduler;
+extern Scheduler JOCKTOSScheduler;
 
 /* -- Private Function Declarations --------------------------------------- */
 
 /* -- Public Functions----------------------------------------------------- */
-void takeSemaphore(T_Semaphore* lock) {
+void takeSemaphore(Semaphore* lock) {
     __asm volatile ("cpsid i" : : : "memory");
     if (!lock->value_) switchRunningTask(&lock->pendingTCBQueue_);
-    JOCKTOSScheduler.running->eState = eBLOCKED;
+    JOCKTOSScheduler.running->state = BLOCKED;
     __asm volatile ("cpsie i" : : : "memory");
 
     __asm volatile ("cpsid i" : : : "memory");
@@ -32,11 +32,11 @@ void takeSemaphore(T_Semaphore* lock) {
     __asm volatile ("cpsie i" : : : "memory");
 }
 
-void giveSemaphore(T_Semaphore* lock) {
+void giveSemaphore(Semaphore* lock) {
     __asm volatile ("cpsid i" : : : "memory");  
     lock->value_ = (lock->value_ + 1) % lock->count;
     if (lock->pendingTCBQueue_) {
-        lock->pendingTCBQueue_->eState = eREADY;
+        lock->pendingTCBQueue_->state = READY;
         moveTCB(&lock->pendingTCBQueue_,
                 &JOCKTOSScheduler.ready,
                 lock->pendingTCBQueue_);
@@ -47,8 +47,8 @@ void giveSemaphore(T_Semaphore* lock) {
 
 void sleep(uint32_t delay) {
     __asm volatile ("cpsid i" : : : "memory");
-    JOCKTOSScheduler.running->u32Delay = currentTime() + delay;
-    JOCKTOSScheduler.running->eState = eSUSPENDED;
+    JOCKTOSScheduler.running->delay = currentTime() + delay;
+    JOCKTOSScheduler.running->state = SUSPENDED;
     switchRunningTask(&JOCKTOSScheduler.suspended);
     __asm volatile ("cpsie i" : : : "memory");
     return;

--- a/jocktos/src/synchro.c
+++ b/jocktos/src/synchro.c
@@ -23,7 +23,7 @@ extern Scheduler JOCKTOSScheduler;
 /* -- Public Functions----------------------------------------------------- */
 void jock_takeSemaphore(Semaphore* lock) {
     __asm volatile ("cpsid i" : : : "memory");
-    if (!lock->value_) switchRunningTask(&lock->pendingTCBQueue_);
+    if (!lock->value_) switchRunningTask(&lock->pending_queue_);
     JOCKTOSScheduler.running->state = BLOCKED;
     __asm volatile ("cpsie i" : : : "memory");
 
@@ -35,19 +35,17 @@ void jock_takeSemaphore(Semaphore* lock) {
 void jock_giveSemaphore(Semaphore* lock) {
     __asm volatile ("cpsid i" : : : "memory");  
     lock->value_ = (lock->value_ + 1) % lock->count;
-    if (lock->pendingTCBQueue_) {
-        lock->pendingTCBQueue_->state = READY;
-        moveTCB(&lock->pendingTCBQueue_,
-                &JOCKTOSScheduler.ready,
-                lock->pendingTCBQueue_);
+    if (lock->pending_queue_) {
+        lock->pending_queue_->state = READY;
+        moveTCB(&lock->pending_queue_, lock->pending_queue_, &JOCKTOSScheduler.ready);
     }
     __asm volatile ("cpsie i" : : : "memory");
     return;
 }
 
-void jock_sleep(uint32_t delay) {
+void jock_sleep(uint32_t delay_ms) {
     __asm volatile ("cpsid i" : : : "memory");
-    JOCKTOSScheduler.running->delay = jock_currentTime() + delay;
+    JOCKTOSScheduler.running->delay_ms = jock_currentTime() + delay_ms;
     JOCKTOSScheduler.running->state = SUSPENDED;
     switchRunningTask(&JOCKTOSScheduler.suspended);
     __asm volatile ("cpsie i" : : : "memory");

--- a/jocktos/src/synchro.c
+++ b/jocktos/src/synchro.c
@@ -21,7 +21,7 @@ extern Scheduler JOCKTOSScheduler;
 /* -- Private Function Declarations --------------------------------------- */
 
 /* -- Public Functions----------------------------------------------------- */
-void takeSemaphore(Semaphore* lock) {
+void jock_takeSemaphore(Semaphore* lock) {
     __asm volatile ("cpsid i" : : : "memory");
     if (!lock->value_) switchRunningTask(&lock->pendingTCBQueue_);
     JOCKTOSScheduler.running->state = BLOCKED;
@@ -32,7 +32,7 @@ void takeSemaphore(Semaphore* lock) {
     __asm volatile ("cpsie i" : : : "memory");
 }
 
-void giveSemaphore(Semaphore* lock) {
+void jock_giveSemaphore(Semaphore* lock) {
     __asm volatile ("cpsid i" : : : "memory");  
     lock->value_ = (lock->value_ + 1) % lock->count;
     if (lock->pendingTCBQueue_) {
@@ -45,9 +45,9 @@ void giveSemaphore(Semaphore* lock) {
     return;
 }
 
-void sleep(uint32_t delay) {
+void jock_sleep(uint32_t delay) {
     __asm volatile ("cpsid i" : : : "memory");
-    JOCKTOSScheduler.running->delay = currentTime() + delay;
+    JOCKTOSScheduler.running->delay = jock_currentTime() + delay;
     JOCKTOSScheduler.running->state = SUSPENDED;
     switchRunningTask(&JOCKTOSScheduler.suspended);
     __asm volatile ("cpsie i" : : : "memory");

--- a/jocktos/src/tcb.c
+++ b/jocktos/src/tcb.c
@@ -23,61 +23,65 @@ TCBError JOCKTOS_TCBError = {0};
 /* -- Public Functions----------------------------------------------------- */
 void insertTCB(volatile TaskControlBlock** head, volatile TaskControlBlock* tcb) {
     if (head == NULL) {
-        JOCKTOS_TCBError.invalidListHead++;
+        JOCKTOS_TCBError.invalid_list_head++;
+        return;
+    }
+    if (tcb == NULL) {
+        JOCKTOS_TCBError.invalid_tcb++;
         return;
     }
     // if tcb is the first entry or the highest priority, updated the head
     if (*head == NULL || tcb->priority > (*head)->priority) {
-        tcb->TCBNext = *head;
+        tcb->next = *head;
         *head = tcb;
     } else {
         // otherwise, iterate across the linked list and insert tcb wrt its priority
         volatile TaskControlBlock* current = *head;
-        while (current->TCBNext != NULL && current->TCBNext->priority >= tcb->priority) {
-            current = current->TCBNext;
+        while (current->next != NULL && current->next->priority >= tcb->priority) {
+            current = current->next;
         }
-        tcb->TCBNext = current->TCBNext;
-        current->TCBNext = tcb;
+        tcb->next = current->next;
+        current->next = tcb;
     }
 }
 
 void removeTCB(volatile TaskControlBlock** head, volatile TaskControlBlock* tcb) {
     // catch and log invalid linked list head
-    if (*head == NULL) {
-        JOCKTOS_TCBError.invalidListHead++;
+    if (head == NULL || *head == NULL) {
+        JOCKTOS_TCBError.invalid_list_head++;
         return;
     }
     // catch and log invalid control block reference
     if (tcb == NULL) {
-        JOCKTOS_TCBError.invalidTCB++;
+        JOCKTOS_TCBError.invalid_tcb++;
         return;
     }
 
     if (*head == tcb) {
-        *head = tcb->TCBNext;
+        *head = tcb->next;
     } else {
         volatile TaskControlBlock* current = *head;
-        while (current->TCBNext != NULL && current->TCBNext != tcb) {
-            current = current->TCBNext;
+        while (current->next != NULL && current->next != tcb) {
+            current = current->next;
         }
-        if (current->TCBNext == tcb) {
-            current->TCBNext = tcb->TCBNext;
+        if (current->next == tcb) {
+            current->next = tcb->next;
         } else {
             // log attempted removal of non-existant TCB
-            JOCKTOS_TCBError.invalidListElement++;
+            JOCKTOS_TCBError.invalid_list_element++;
         }
     }
 }
 
 void updateTCB(volatile TaskControlBlock** head, volatile TaskControlBlock* tcb, uint8_t priority) {
     // catch and log invalid linked list head
-    if (*head == NULL) {
-        JOCKTOS_TCBError.invalidListHead++;
+    if (head == NULL ||*head == NULL) {
+        JOCKTOS_TCBError.invalid_list_head++;
         return;
     }
     // catch and log invalid control block reference
     if (tcb == NULL) {
-        JOCKTOS_TCBError.invalidTCB++;
+        JOCKTOS_TCBError.invalid_tcb++;
         return;
     }
     if (tcb->priority == priority) return; // NOP if priority doesn't change
@@ -86,19 +90,19 @@ void updateTCB(volatile TaskControlBlock** head, volatile TaskControlBlock* tcb,
     insertTCB(head, tcb);          // Reinsert the node into the list at its new position
 }
 
-void moveTCB(volatile TaskControlBlock** currentHead, volatile TaskControlBlock** newHead, volatile TaskControlBlock* tcb) {
+void moveTCB(volatile TaskControlBlock** source, volatile TaskControlBlock* tcb, volatile TaskControlBlock** destination) {
     // catch and log invalid linked list head
-    if (currentHead == NULL || newHead == NULL) {
-        JOCKTOS_TCBError.invalidListHead++;
+    if (source == NULL || destination == NULL) {
+        JOCKTOS_TCBError.invalid_list_head++;
         return;
     }
     // catch and log invalid control block reference
     if (tcb == NULL) {
-        JOCKTOS_TCBError.invalidTCB++;
+        JOCKTOS_TCBError.invalid_tcb++;
         return;
     }
-    removeTCB(currentHead, tcb);
-    insertTCB(newHead, tcb);
+    removeTCB(source, tcb);
+    insertTCB(destination, tcb);
 }
 
 /* -- Private Functions --------------------------------------------------- */

--- a/jocktos/src/tcb.c
+++ b/jocktos/src/tcb.c
@@ -16,24 +16,24 @@
 
 /* -- Local Globals (not for libraries with application instantiation) ---- */
 
-T_TCBError JOCKTOS_TCBError = {0};
+TCBError JOCKTOS_TCBError = {0};
 
 /* -- Private Function Declarations --------------------------------------- */
 
 /* -- Public Functions----------------------------------------------------- */
-void insertTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* tcb) {
+void insertTCB(volatile TaskControlBlock** head, volatile TaskControlBlock* tcb) {
     if (head == NULL) {
         JOCKTOS_TCBError.invalidListHead++;
         return;
     }
     // if tcb is the first entry or the highest priority, updated the head
-    if (*head == NULL || tcb->u8Priority > (*head)->u8Priority) {
+    if (*head == NULL || tcb->priority > (*head)->priority) {
         tcb->TCBNext = *head;
         *head = tcb;
     } else {
         // otherwise, iterate across the linked list and insert tcb wrt its priority
-        volatile T_TaskControlBlock* current = *head;
-        while (current->TCBNext != NULL && current->TCBNext->u8Priority >= tcb->u8Priority) {
+        volatile TaskControlBlock* current = *head;
+        while (current->TCBNext != NULL && current->TCBNext->priority >= tcb->priority) {
             current = current->TCBNext;
         }
         tcb->TCBNext = current->TCBNext;
@@ -41,7 +41,7 @@ void insertTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* 
     }
 }
 
-void removeTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* tcb) {
+void removeTCB(volatile TaskControlBlock** head, volatile TaskControlBlock* tcb) {
     // catch and log invalid linked list head
     if (*head == NULL) {
         JOCKTOS_TCBError.invalidListHead++;
@@ -56,7 +56,7 @@ void removeTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* 
     if (*head == tcb) {
         *head = tcb->TCBNext;
     } else {
-        volatile T_TaskControlBlock* current = *head;
+        volatile TaskControlBlock* current = *head;
         while (current->TCBNext != NULL && current->TCBNext != tcb) {
             current = current->TCBNext;
         }
@@ -69,7 +69,7 @@ void removeTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* 
     }
 }
 
-void updateTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* tcb, uint8_t priority) {
+void updateTCB(volatile TaskControlBlock** head, volatile TaskControlBlock* tcb, uint8_t priority) {
     // catch and log invalid linked list head
     if (*head == NULL) {
         JOCKTOS_TCBError.invalidListHead++;
@@ -80,13 +80,13 @@ void updateTCB(volatile T_TaskControlBlock** head, volatile T_TaskControlBlock* 
         JOCKTOS_TCBError.invalidTCB++;
         return;
     }
-    if (tcb->u8Priority == priority) return; // NOP if priority doesn't change
+    if (tcb->priority == priority) return; // NOP if priority doesn't change
     removeTCB(head, tcb);          // Remove the node from the list
-    tcb->u8Priority = priority; // Update the priority of the node
+    tcb->priority = priority; // Update the priority of the node
     insertTCB(head, tcb);          // Reinsert the node into the list at its new position
 }
 
-void moveTCB(volatile T_TaskControlBlock** currentHead, volatile T_TaskControlBlock** newHead, volatile T_TaskControlBlock* tcb) {
+void moveTCB(volatile TaskControlBlock** currentHead, volatile TaskControlBlock** newHead, volatile TaskControlBlock* tcb) {
     // catch and log invalid linked list head
     if (currentHead == NULL || newHead == NULL) {
         JOCKTOS_TCBError.invalidListHead++;

--- a/jocktos/src/timers.c
+++ b/jocktos/src/timers.c
@@ -20,7 +20,7 @@
 
 /* -- Private Function Declarations --------------------------------------- */
 
-void SysTick_Configuration(int freq) {
+void sysTickConfiguration(int freq) {
     __asm volatile ("cpsid i" : : : "memory");
     SysTick->LOAD = (SystemCoreClock / freq) - 1; // Set the reload value for a 1ms interrupt
     SysTick->VAL = 0;                             // Clear the current value

--- a/jocktos/test/test_allocator.c
+++ b/jocktos/test/test_allocator.c
@@ -12,15 +12,15 @@ void testInitAllocator(void) {
     TEST_CASE("Even multiple of block size") {
         Allocator allocator;
         uint8_t memory[128];
-        initAllocator(&allocator, memory, 128, 16);
+        initAllocator(&allocator, 16, memory, 128);
 
         ASSERT_EQUAL_INT(allocator.memory.size, 112, "incorrect size after initialization");
-        ASSERT_EQUAL_INT(allocator.blockSize, 16, "incorrect block size after initialization");
+        ASSERT_EQUAL_INT(allocator.block_size, 16, "incorrect block size after initialization");
         ASSERT_EQUAL_INT(allocator.bitmaps.size, 7, "incorrect bitmap size after initialization"); 
 
-        ASSERT_EQUAL_PTR((uint8_t*)(allocator.bitmaps.used), memory, "alloc bitmap placement is wrong"); 
-        ASSERT_EQUAL_PTR((uint8_t*)(allocator.bitmaps.alloc), memory + 2, "used bitmap placement is wrong");  
-        ASSERT_EQUAL_PTR((uint8_t*)(allocator.memory.head), memory + 4, "alloc bitmap placement is wrong"); 
+        ASSERT_EQUAL_PTR((uint8_t*)(allocator.bitmaps.used), memory, "heads bitmap placement is wrong"); 
+        ASSERT_EQUAL_PTR((uint8_t*)(allocator.bitmaps.heads), memory + 2, "used bitmap placement is wrong");  
+        ASSERT_EQUAL_PTR((uint8_t*)(allocator.memory.head), memory + 4, "heads bitmap placement is wrong"); 
 
     } CASE_COMPLETE;
 
@@ -40,12 +40,12 @@ void testAllocate() {
         Allocator allocator;
         uint8_t memory[128];
         for (int index = 0; index < 128; index++) memory[index] = 0;
-        initAllocator(&allocator, memory, 128, 16);
+        initAllocator(&allocator, 16, memory, 128);
         void* block = allocate(&allocator, allocator.memory.size);
         ASSERT_EQUAL_PTR(block, allocator.memory.head, "incorrect block head returned");
         void* block2 = allocate(&allocator, 16);
         ASSERT_EQUAL_PTR(block2, NULL, "invalid allocation returned non-null");
-        ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 0), "alloc bit not set");
+        ASSERT_TRUE(get_bit(allocator.bitmaps.heads, 0), "heads bit not set");
         for (uint16_t i = 0; i < allocator.bitmaps.size; i++) {
             ASSERT_TRUE(get_bit(allocator.bitmaps.used, i), "used bit not set");
         }
@@ -55,13 +55,13 @@ void testAllocate() {
         Allocator allocator;
         uint8_t memory[128];
         for (int index = 0; index < 128; index++) memory[index] = 0;
-        initAllocator(&allocator, memory, 128, 16);
+        initAllocator(&allocator, 16, memory, 128);
 
         void* block = allocate(&allocator, 1024);
         ASSERT_EQUAL_PTR(block, NULL, "invalid allocation returned non-null");
 
         for (uint16_t i = 0; i < allocator.bitmaps.size; i++) {
-            ASSERT_FALSE(get_bit(allocator.bitmaps.alloc, i), "alloc bit was set");
+            ASSERT_FALSE(get_bit(allocator.bitmaps.heads, i), "heads bit was set");
             ASSERT_FALSE(get_bit(allocator.bitmaps.used, i),  "used bit was set");
         }
     } CASE_COMPLETE;
@@ -70,18 +70,18 @@ void testAllocate() {
         Allocator allocator;
         uint8_t memory[4096];
         for (int index = 0; index < 4096; index++) memory[index] = 0;
-        initAllocator(&allocator, memory, 512, 16);
+        initAllocator(&allocator, 16, memory, 512);
 
         void* block1 = allocate(&allocator, 16 * 20);
         void* block2 = allocate(&allocator, 16);
         ASSERT_NOT_EQUAL_PTR(block1, NULL, "valid allocation returned null");
         ASSERT_NOT_EQUAL_PTR(block2, NULL, "valid allocation returned null");
 
-        ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 0), "alloc bit not set");
+        ASSERT_TRUE(get_bit(allocator.bitmaps.heads, 0), "heads bit not set");
         for (uint16_t i = 0; i < 20; i++) {
             ASSERT_TRUE(get_bit(allocator.bitmaps.used, i), "used bit not set");
         }
-        ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 20), "alloc bit not set");
+        ASSERT_TRUE(get_bit(allocator.bitmaps.heads, 20), "heads bit not set");
         ASSERT_TRUE(get_bit(allocator.bitmaps.used, 20), "used bit not set");
 
     } CASE_COMPLETE;
@@ -90,7 +90,7 @@ void testAllocate() {
         Allocator allocator;
         uint8_t memory[128];
         for (int index = 0; index < 128; index++) memory[index] = 0;
-        initAllocator(&allocator, memory, 128, 16);
+        initAllocator(&allocator, 16, memory, 128);
 
         void* block1 = allocate(&allocator, 17);
         void* block2 = allocate(&allocator, 17);
@@ -99,8 +99,8 @@ void testAllocate() {
 
         ASSERT_EQUAL_PTR((uint8_t*)block1 + 32, (uint8_t*)block2, "blocks not adjacent");
 
-        ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 0), "alloc bit not set");
-        ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 2), "alloc bit not set");
+        ASSERT_TRUE(get_bit(allocator.bitmaps.heads, 0), "heads bit not set");
+        ASSERT_TRUE(get_bit(allocator.bitmaps.heads, 2), "heads bit not set");
         ASSERT_TRUE(get_bit(allocator.bitmaps.used, 0), "used bit not set");
         ASSERT_TRUE(get_bit(allocator.bitmaps.used, 1), "used bit not set");
         ASSERT_TRUE(get_bit(allocator.bitmaps.used, 2), "used bit not set");
@@ -115,12 +115,12 @@ void testDeallocate() {
         Allocator allocator;
         uint8_t memory[128];
         for (int index = 0; index < 128; index++) memory[index] = 0;
-        initAllocator(&allocator, memory, 128, 16);
+        initAllocator(&allocator, 16, memory, 128);
 
         void* block = allocate(&allocator, 16);
         ASSERT_TRUE(deallocate(&allocator, block), "deallocation failed");
 
-        ASSERT_FALSE(get_bit(allocator.bitmaps.alloc, 0), "alloc bit was set");
+        ASSERT_FALSE(get_bit(allocator.bitmaps.heads, 0), "heads bit was set");
         ASSERT_FALSE(get_bit(allocator.bitmaps.used, 0), "used bit was set");
 
     } CASE_COMPLETE;
@@ -129,19 +129,19 @@ void testDeallocate() {
         Allocator allocator;
         uint8_t memory[4096];
         for (int index = 0; index < 4096; index++) memory[index] = 0;
-        initAllocator(&allocator, memory, 4096, 16);
+        initAllocator(&allocator, 16, memory, 4096);
 
         void* block1 = allocate(&allocator, 16 * 12);
         void* block2 = allocate(&allocator, 16 * 20);
 
         ASSERT_TRUE(deallocate(&allocator, block1), "deallocating block1 failed");
 
-        ASSERT_FALSE(get_bit(allocator.bitmaps.alloc, 0), "alloc bit still set after deallocation");
+        ASSERT_FALSE(get_bit(allocator.bitmaps.heads, 0), "heads bit still set after deallocation");
         for (uint16_t i = 0; i < 12; i++) {
             ASSERT_FALSE(get_bit(allocator.bitmaps.used, i), "used bit still set after deallocation");
         }
 
-        ASSERT_TRUE(get_bit(allocator.bitmaps.alloc, 12), "next allocs bit cleared after deallocation");
+        ASSERT_TRUE(get_bit(allocator.bitmaps.heads, 12), "next allocs bit cleared after deallocation");
         for (uint16_t i = 0; i < 20; i++) {
             ASSERT_TRUE(get_bit(allocator.bitmaps.used, 12 + i), "next used bit cleared after deallocation");
         }
@@ -154,12 +154,12 @@ void testDeallocate() {
         Allocator allocator;
         uint8_t memory[128];
         for (int index = 0; index < 128; index++) memory[index] = 0;
-        initAllocator(&allocator, memory, 128, 16);
+        initAllocator(&allocator, 16, memory, 128);
         void* block = (uint8_t*)(allocator.memory.head) + 2;
 
         ASSERT_FALSE(deallocate(&allocator, block), "invalid block was deallocation without error");
         for (uint16_t i = 0; i < 8; i++) {
-            ASSERT_FALSE(get_bit(allocator.bitmaps.alloc, i), "alloc bit was cleared during invalid deallocation");
+            ASSERT_FALSE(get_bit(allocator.bitmaps.heads, i), "heads bit was cleared during invalid deallocation");
         }
     } CASE_COMPLETE;
 }


### PR DESCRIPTION
Changes: [WIP]
 - [x] Remove data type prefix from typedefs and struct members
 - [x] Add `jock_` prefix to user facing API functions
 - [x] Clarify function vs. variable format:
    @JGoard  Currently we're using camelCase for functions *and* variables, and PascalCase for typedefs. Do we want to switch either functions or variables to snake_case to better distinguish them? There's a reasonable argument to be made for either, or leaving as-is, just comes down to our preference. Personally I'd  make function snake_case or leave as is