### PR TITLE
Jg/devcontainer usb fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,12 +31,14 @@
 				"actboy168.tasks",
 				"webfreak.debug"
 			]
-			
 		}
 	},
-	"runArgs": ["--privileged","-v", "-i",         "--expose=3333",
-	"--expose=4444",
-	"--expose=6666"]
+	"runArgs": ["--privileged",
+				"-v", 
+				"-i", 
+				"--expose=3333",
+				"--expose=4444",
+				"--expose=6666"]
 
 	
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,9 @@
 			
 		}
 	},
-	// "runArgs": ["--privileged","-v"]
+	"runArgs": ["--privileged","-v", "-i",         "--expose=3333",
+	"--expose=4444",
+	"--expose=6666"]
 
 	
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,6 @@
         "--privileged",
         "jocktos:latest",
         "sh"
-      
       ],
       "dependsOn":[
         "Bind USB Device",
@@ -114,7 +113,7 @@
       "type": "shell",
       "command": "openocd",
       "args": [
-        // "-d",    //Used for Verbose debugging of openocd. Not mandatory
+        "-d",    //Used for Verbose debugging of openocd. Not mandatory
         "-f", 
         "board/st_nucleo_f3.cfg",
         "-c", 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,26 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Attach USB Nucleo",
+      "type": "shell",
+      "command": "usbipd",
+      "args": [
+        "attach",    
+        "--wsl",
+        "--hardware-id",
+        "0483:374b",
+      ],
+      "dependsOn":[
+        "Bind USB Device"
+      ],
+      "options": {
+        "statusbar": {
+        "id": "gear",
+        "color": "terminal.ansiGreen"
+        }      
+      }
+    },
+    {
       "label": "Docker Instance",
       "type": "shell",
       "command": "docker",
@@ -25,7 +45,8 @@
       },
       "options": {
         "statusbar": {
-          "color": "#09fa05"
+          "color": "#09fa05",
+          "hide": true,
         }
       },
       "group": {
@@ -62,7 +83,7 @@
       "command": "bash",
       "args": [
         "-c",
-        "cd ${workspaceFolder}/jocktos && make clean && make debug"],
+        "cd ${workspaceFolder}/jocktos && make clean && make release"],
       "icon": {
         "id": "tools",
         "color": "terminal.ansiGreen"
@@ -93,22 +114,6 @@
       }
     },
     {
-      "label": "Attach USB Device",
-      "type": "shell",
-      "command": "usbipd",
-      "args": [
-        "attach",    
-        "--wsl",
-        "--hardware-id",
-        "0483:374b",
-      ],
-      "options": {
-        "statusbar": {
-          "hide" : true
-        }      
-      }
-    },
-    {
       "label": "Flash Device Docker",
       "type": "shell",
       "command": "openocd",
@@ -121,7 +126,7 @@
         "-c", 
         "reset init",
         "-c", 
-        "flash write_image erase /jocktos/jocktos/build/debug/firmware.elf",
+        "flash write_image erase jocktos/build/debug/firmware.elf",
         "-c", 
         "shutdown"
       ],

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM ubuntu:23.10
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND noninteractive
 
+# place timezone data /etc/timezone
 # update and install basic tools
 RUN apt-get update && \
     apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -67,17 +67,20 @@ To get started with JOCKTOS, follow this procedure:
    docker build -t jocktos:latest .
 This will build you the latest jocktos image located in the root directory of the docker file.
 
-2. **Open Project in VSCode**:
-   * Open the project within VSCode, and install all recommended extensions for use with this project.
+2. **Open Project in VSCode and Configure USB Device**:
+   * Open the project within VSCode, and install all recommended extensions.
+   * If using a Windows Host: Use the 'Attach USB Nucleo' task to have usbipd bind to your usb device for use with a container/wsl. The VID:PID combo may differ depending on your Cortex-M4 device.
 
-3. **Create Docker Instance, and attach VSCode**
-   * Use the VSCode Task *Docker Instance* to create a new docker container.
-   * Now, in the docker extension tab, right-click on the new container and *Attach Visual Studio Code.*
+3. **Use Devcontainers to launch new Container**
+   * Select the bottom left remote window button.
+   * Select 'Reopen in Container' from the drop down menu
+   * The window should reload and the container should not be launching/
 4. **Compile and Debug SW within docker container**
-   * Wait a few minutes after attaching VSCode to the docker container for proper extension initializations
-   * Reload the window when all extensions are installed.
+   * Wait a few minutes after attaching VSCode to the docker container for proper extension initializations, reload the window if prompted for the cortex debugger.
 5. **Now you are ready to go!**
    * Run the compile debug task to ensure that your enviroment is indeed setup correctly
+
+Please Note: USBIPD and WSL are still very finicky. If you disconnect the USB device, you will need to relaunch your container, and rebind on the host enviroment if you are using windows.
 
 ## License
 JOCKTOS is licensed under the MIT License.  See the [LICENSE](https://opensource.org/license/mit) for more information


### PR DESCRIPTION
Updated devcontainer launching method to use VScodes integrated env a bit easier